### PR TITLE
Transpiler refactor

### DIFF
--- a/jaclang/jac/importer.py
+++ b/jaclang/jac/importer.py
@@ -5,7 +5,7 @@ import sys
 import traceback
 import types
 from os import makedirs, path
-from typing import Callable, Optional
+from typing import Optional
 
 from jaclang.jac.constant import Constants as Con, Values as Val
 from jaclang.jac.transpiler import Transpiler
@@ -13,8 +13,8 @@ from jaclang.jac.utils import add_line_numbers, clip_code_section
 
 
 def import_jac_module(
+    import_type: str,
     target: str,
-    import_type: str = "blue",
     base_path: Optional[str] = None,
     cachable: bool = False,
 ) -> Optional[types.ModuleType]:
@@ -41,7 +41,6 @@ def import_jac_module(
     makedirs(dev_dir, exist_ok=True)
     py_file_path = path.join(dev_dir, module_name + ".py")
 
-    transpiler = Transpiler()
     if (
         cachable
         and path.exists(py_file_path)
@@ -54,7 +53,7 @@ def import_jac_module(
             from jaclang.jac.passes.blue import BluePygenPass as pygen_pass, pass_schedule
         elif import_type == "purple":
             from jaclang.jac.passes.purple import PurplePygenPass as pygen_pass, pass_schedule
-        code_string = transpiler(file_path=full_target, base_dir=caller_dir, target=pygen_pass, pass_schedule=pass_schedule)
+        code_string = Transpiler.transpile(file_path=full_target, base_dir=caller_dir, target=pygen_pass, pass_schedule=pass_schedule)
 
     with open(py_file_path, "w") as f:
         f.write(code_string)

--- a/jaclang/jac/importer.py
+++ b/jaclang/jac/importer.py
@@ -50,10 +50,21 @@ def import_jac_module(
             code_string = f.read()
     else:
         if import_type == "blue":
-            from jaclang.jac.passes.blue import BluePygenPass as pygen_pass, pass_schedule
+            from jaclang.jac.passes.blue import (
+                BluePygenPass as pygen_pass,
+                pass_schedule,
+            )
         elif import_type == "purple":
-            from jaclang.jac.passes.purple import PurplePygenPass as pygen_pass, pass_schedule
-        code_string = Transpiler.transpile(file_path=full_target, base_dir=caller_dir, target=pygen_pass, pass_schedule=pass_schedule)
+            from jaclang.jac.passes.purple import (
+                PurplePygenPass as pygen_pass,
+                pass_schedule,
+            )
+        code_string = Transpiler.transpile(
+            file_path=full_target,
+            base_dir=caller_dir,
+            target=pygen_pass,
+            pass_schedule=pass_schedule,
+        )
 
     with open(py_file_path, "w") as f:
         f.write(code_string)

--- a/jaclang/jac/importer.py
+++ b/jaclang/jac/importer.py
@@ -8,13 +8,13 @@ from os import makedirs, path
 from typing import Callable, Optional
 
 from jaclang.jac.constant import Constants as Con, Values as Val
-from jaclang.jac.transpiler import transpile_jac_blue, transpile_jac_purple
+from jaclang.jac.transpiler import Transpiler
 from jaclang.jac.utils import add_line_numbers, clip_code_section
 
 
 def import_jac_module(
-    transpiler_func: Callable,
     target: str,
+    import_type: str = "blue",
     base_path: Optional[str] = None,
     cachable: bool = False,
 ) -> Optional[types.ModuleType]:
@@ -40,6 +40,8 @@ def import_jac_module(
     dev_dir = path.join(caller_dir, "__jac_gen__")
     makedirs(dev_dir, exist_ok=True)
     py_file_path = path.join(dev_dir, module_name + ".py")
+
+    transpiler = Transpiler()
     if (
         cachable
         and path.exists(py_file_path)
@@ -48,7 +50,11 @@ def import_jac_module(
         with open(py_file_path, "r") as f:
             code_string = f.read()
     else:
-        code_string = transpiler_func(file_path=full_target, base_dir=caller_dir)
+        if import_type == "blue":
+            from jaclang.jac.passes.blue import BluePygenPass as pygen_pass, pass_schedule
+        elif import_type == "purple":
+            from jaclang.jac.passes.purple import PurplePygenPass as pygen_pass, pass_schedule
+        code_string = transpiler(file_path=full_target, base_dir=caller_dir, target=pygen_pass, pass_schedule=pass_schedule)
 
     with open(py_file_path, "w") as f:
         f.write(code_string)
@@ -121,11 +127,11 @@ def jac_blue_import(
     target: str, base_path: Optional[str] = None, save_file: bool = False
 ) -> Optional[types.ModuleType]:
     """Jac Blue Imports."""
-    return import_jac_module(transpile_jac_blue, target, base_path, save_file)
+    return import_jac_module("blue", target, base_path, save_file)
 
 
 def jac_purple_import(
     target: str, base_path: Optional[str] = None, save_file: bool = False
 ) -> Optional[types.ModuleType]:
     """Jac Purple Imports."""
-    return import_jac_module(transpile_jac_purple, target, base_path, save_file)
+    return import_jac_module("purple", target, base_path, save_file)

--- a/jaclang/jac/passes/blue/import_pass.py
+++ b/jaclang/jac/passes/blue/import_pass.py
@@ -48,7 +48,7 @@ class ImportPass(Pass):
 
     def import_module(self, node: ast.Import, mod_path: str) -> ast.AstNode:
         """Import a module."""
-        from jaclang.jac.transpiler import jac_file_to_pass
+        from jaclang.jac.transpiler import Transpiler
         from jaclang.jac.passes.blue.ast_build_pass import AstBuildPass
 
         base_dir = path.dirname(mod_path)
@@ -63,7 +63,7 @@ class ImportPass(Pass):
 
         if not path.exists(target):
             self.error(f"Could not find module {target}")
-        mod = jac_file_to_pass(
+        mod = Transpiler.to_pass(
             file_path=target, base_dir=base_dir, target=AstBuildPass
         ).ir
         if isinstance(mod, ast.Module):

--- a/jaclang/jac/passes/blue/tests/test_blue_pygen_pass.py
+++ b/jaclang/jac/passes/blue/tests/test_blue_pygen_pass.py
@@ -1,8 +1,8 @@
 """Test ast build pass module."""
 import inspect
 
-from jaclang.jac.passes.blue import BluePygenPass
-from jaclang.jac.transpiler import jac_file_to_pass, transpile_jac_blue
+from jaclang.jac.passes.blue import BluePygenPass, pass_schedule as blue_pass_schedule
+from jaclang.jac.transpiler import Transpiler
 from jaclang.jac.utils import get_ast_nodes_as_snake_case as ast_snakes
 from jaclang.utils.test import TestCaseMicroSuite
 
@@ -16,15 +16,15 @@ class BluePygenPassTests(TestCaseMicroSuite):
 
     def test_jac_cli(self) -> None:
         """Basic test for pass."""
-        code_gen = jac_file_to_pass(
-            self.fixture_abs_path("../../../../../cli/cli.jac"), target=BluePygenPass
+        code_gen = Transpiler.to_pass(
+            self.fixture_abs_path("../../../../../cli/cli.jac"), target=BluePygenPass, pass_schedule=blue_pass_schedule
         )
         self.assertFalse(code_gen.errors_had)
 
     def test_pipe_operator(self) -> None:
         """Basic test for pass."""
-        code_gen = jac_file_to_pass(
-            self.fixture_abs_path("codegentext.jac"), target=BluePygenPass
+        code_gen = Transpiler.to_pass(
+            self.fixture_abs_path("codegentext.jac"), target=BluePygenPass, pass_schedule=blue_pass_schedule
         )
         self.assertFalse(code_gen.errors_had)
         self.assertIn(
@@ -37,8 +37,8 @@ class BluePygenPassTests(TestCaseMicroSuite):
 
     def test_atomic_pipe_operator(self) -> None:
         """Basic test for pass."""
-        code_gen = jac_file_to_pass(
-            self.fixture_abs_path("codegentext.jac"), target=BluePygenPass
+        code_gen = Transpiler.to_pass(
+            self.fixture_abs_path("codegentext.jac"), target=BluePygenPass, pass_schedule=blue_pass_schedule
         )
         self.assertFalse(code_gen.errors_had)
         self.assertIn(
@@ -47,8 +47,8 @@ class BluePygenPassTests(TestCaseMicroSuite):
 
     def test_pipe_operator_multi_param(self) -> None:
         """Basic test for pass."""
-        code_gen = jac_file_to_pass(
-            self.fixture_abs_path("codegentext.jac"), target=BluePygenPass
+        code_gen = Transpiler.to_pass(
+            self.fixture_abs_path("codegentext.jac"), target=BluePygenPass, pass_schedule=blue_pass_schedule
         )
         self.assertFalse(code_gen.errors_had)
         self.assertIn("self.func(*args, **kwargs)", code_gen.ir.meta["py_code"])
@@ -57,8 +57,8 @@ class BluePygenPassTests(TestCaseMicroSuite):
 
     def test_with_stmt(self) -> None:
         """Basic test for pass."""
-        code_gen = jac_file_to_pass(
-            self.fixture_abs_path("codegentext.jac"), target=BluePygenPass
+        code_gen = Transpiler.to_pass(
+            self.fixture_abs_path("codegentext.jac"), target=BluePygenPass, pass_schedule=blue_pass_schedule
         )
         self.assertFalse(code_gen.errors_had)
         self.assertIn(
@@ -68,16 +68,16 @@ class BluePygenPassTests(TestCaseMicroSuite):
 
     def test_empty_codeblock(self) -> None:
         """Basic test for pass."""
-        code_gen = jac_file_to_pass(
-            self.fixture_abs_path("codegentext.jac"), target=BluePygenPass
+        code_gen = Transpiler.to_pass(
+            self.fixture_abs_path("codegentext.jac"), target=BluePygenPass, pass_schedule=blue_pass_schedule
         )
         self.assertFalse(code_gen.errors_had)
         self.assertIn("pass", code_gen.ir.meta["py_code"])
 
     def test_enum_gen(self) -> None:
         """Basic test for pass."""
-        code_gen = jac_file_to_pass(
-            self.fixture_abs_path("codegentext.jac"), target=BluePygenPass
+        code_gen = Transpiler.to_pass(
+            self.fixture_abs_path("codegentext.jac"), target=BluePygenPass, pass_schedule=blue_pass_schedule
         )
         self.assertFalse(code_gen.errors_had)
         self.assertIn(
@@ -110,7 +110,7 @@ class BluePygenPassTests(TestCaseMicroSuite):
 
     def micro_suite_test(self, filename: str) -> None:
         """Parse micro jac file."""
-        code_gen = transpile_jac_blue(filename, "")
+        code_gen = Transpiler()(self.fixture_abs_path(filename), target=BluePygenPass, pass_schedule=blue_pass_schedule)
         self.assertGreater(len(code_gen), 10)
 
 

--- a/jaclang/jac/passes/blue/tests/test_blue_pygen_pass.py
+++ b/jaclang/jac/passes/blue/tests/test_blue_pygen_pass.py
@@ -110,7 +110,7 @@ class BluePygenPassTests(TestCaseMicroSuite):
 
     def micro_suite_test(self, filename: str) -> None:
         """Parse micro jac file."""
-        code_gen = Transpiler()(self.fixture_abs_path(filename), target=BluePygenPass, pass_schedule=blue_pass_schedule)
+        code_gen = Transpiler.transpile(self.fixture_abs_path(filename), target=BluePygenPass, pass_schedule=blue_pass_schedule)
         self.assertGreater(len(code_gen), 10)
 
 

--- a/jaclang/jac/passes/blue/tests/test_blue_pygen_pass.py
+++ b/jaclang/jac/passes/blue/tests/test_blue_pygen_pass.py
@@ -17,14 +17,18 @@ class BluePygenPassTests(TestCaseMicroSuite):
     def test_jac_cli(self) -> None:
         """Basic test for pass."""
         code_gen = Transpiler.to_pass(
-            self.fixture_abs_path("../../../../../cli/cli.jac"), target=BluePygenPass, pass_schedule=blue_pass_schedule
+            self.fixture_abs_path("../../../../../cli/cli.jac"),
+            target=BluePygenPass,
+            pass_schedule=blue_pass_schedule,
         )
         self.assertFalse(code_gen.errors_had)
 
     def test_pipe_operator(self) -> None:
         """Basic test for pass."""
         code_gen = Transpiler.to_pass(
-            self.fixture_abs_path("codegentext.jac"), target=BluePygenPass, pass_schedule=blue_pass_schedule
+            self.fixture_abs_path("codegentext.jac"),
+            target=BluePygenPass,
+            pass_schedule=blue_pass_schedule,
         )
         self.assertFalse(code_gen.errors_had)
         self.assertIn(
@@ -38,7 +42,9 @@ class BluePygenPassTests(TestCaseMicroSuite):
     def test_atomic_pipe_operator(self) -> None:
         """Basic test for pass."""
         code_gen = Transpiler.to_pass(
-            self.fixture_abs_path("codegentext.jac"), target=BluePygenPass, pass_schedule=blue_pass_schedule
+            self.fixture_abs_path("codegentext.jac"),
+            target=BluePygenPass,
+            pass_schedule=blue_pass_schedule,
         )
         self.assertFalse(code_gen.errors_had)
         self.assertIn(
@@ -48,7 +54,9 @@ class BluePygenPassTests(TestCaseMicroSuite):
     def test_pipe_operator_multi_param(self) -> None:
         """Basic test for pass."""
         code_gen = Transpiler.to_pass(
-            self.fixture_abs_path("codegentext.jac"), target=BluePygenPass, pass_schedule=blue_pass_schedule
+            self.fixture_abs_path("codegentext.jac"),
+            target=BluePygenPass,
+            pass_schedule=blue_pass_schedule,
         )
         self.assertFalse(code_gen.errors_had)
         self.assertIn("self.func(*args, **kwargs)", code_gen.ir.meta["py_code"])
@@ -58,7 +66,9 @@ class BluePygenPassTests(TestCaseMicroSuite):
     def test_with_stmt(self) -> None:
         """Basic test for pass."""
         code_gen = Transpiler.to_pass(
-            self.fixture_abs_path("codegentext.jac"), target=BluePygenPass, pass_schedule=blue_pass_schedule
+            self.fixture_abs_path("codegentext.jac"),
+            target=BluePygenPass,
+            pass_schedule=blue_pass_schedule,
         )
         self.assertFalse(code_gen.errors_had)
         self.assertIn(
@@ -69,7 +79,9 @@ class BluePygenPassTests(TestCaseMicroSuite):
     def test_empty_codeblock(self) -> None:
         """Basic test for pass."""
         code_gen = Transpiler.to_pass(
-            self.fixture_abs_path("codegentext.jac"), target=BluePygenPass, pass_schedule=blue_pass_schedule
+            self.fixture_abs_path("codegentext.jac"),
+            target=BluePygenPass,
+            pass_schedule=blue_pass_schedule,
         )
         self.assertFalse(code_gen.errors_had)
         self.assertIn("pass", code_gen.ir.meta["py_code"])
@@ -77,7 +89,9 @@ class BluePygenPassTests(TestCaseMicroSuite):
     def test_enum_gen(self) -> None:
         """Basic test for pass."""
         code_gen = Transpiler.to_pass(
-            self.fixture_abs_path("codegentext.jac"), target=BluePygenPass, pass_schedule=blue_pass_schedule
+            self.fixture_abs_path("codegentext.jac"),
+            target=BluePygenPass,
+            pass_schedule=blue_pass_schedule,
         )
         self.assertFalse(code_gen.errors_had)
         self.assertIn(
@@ -110,7 +124,11 @@ class BluePygenPassTests(TestCaseMicroSuite):
 
     def micro_suite_test(self, filename: str) -> None:
         """Parse micro jac file."""
-        code_gen = Transpiler.transpile(self.fixture_abs_path(filename), target=BluePygenPass, pass_schedule=blue_pass_schedule)
+        code_gen = Transpiler.transpile(
+            self.fixture_abs_path(filename),
+            target=BluePygenPass,
+            pass_schedule=blue_pass_schedule,
+        )
         self.assertGreater(len(code_gen), 10)
 
 

--- a/jaclang/jac/passes/blue/tests/test_decl_def_match_pass.py
+++ b/jaclang/jac/passes/blue/tests/test_decl_def_match_pass.py
@@ -1,6 +1,6 @@
 """Test pass module."""
 from jaclang.jac.passes.blue import DeclDefMatchPass
-from jaclang.jac.transpiler import jac_file_to_pass
+from jaclang.jac.transpiler import Transpiler
 from jaclang.utils.test import TestCase
 
 
@@ -13,7 +13,7 @@ class DeclDefMatchPassTests(TestCase):
 
     def test_import_values_avail(self) -> None:
         """Basic test for pass."""
-        state = jac_file_to_pass(
+        state = Transpiler.to_pass(
             self.fixture_abs_path("base.jac"), "", DeclDefMatchPass
         )
         self.assertFalse(state.errors_had)
@@ -22,7 +22,7 @@ class DeclDefMatchPassTests(TestCase):
 
     def test_ability_connected_to_decl(self) -> None:
         """Basic test for pass."""
-        state = jac_file_to_pass(
+        state = Transpiler.to_pass(
             self.fixture_abs_path("base.jac"), "", DeclDefMatchPass
         )
         self.assertFalse(state.errors_had)
@@ -33,7 +33,7 @@ class DeclDefMatchPassTests(TestCase):
 
     def test_ability_connected_to_decl_post(self) -> None:
         """Basic test for pass."""
-        state = jac_file_to_pass(
+        state = Transpiler.to_pass(
             self.fixture_abs_path("base2.jac"), "", DeclDefMatchPass
         )
         self.assertFalse(state.errors_had)
@@ -44,7 +44,7 @@ class DeclDefMatchPassTests(TestCase):
 
     def test_collision_error_correct(self) -> None:
         """Basic test for multi defs."""
-        state = jac_file_to_pass(
+        state = Transpiler.to_pass(
             self.fixture_abs_path("decls.jac"), "", DeclDefMatchPass
         )
         self.assertTrue(state.errors_had)

--- a/jaclang/jac/passes/blue/tests/test_import_pass.py
+++ b/jaclang/jac/passes/blue/tests/test_import_pass.py
@@ -1,6 +1,6 @@
 """Test pass module."""
 from jaclang.jac.passes.blue import ImportPass
-from jaclang.jac.transpiler import jac_file_to_pass
+from jaclang.jac.transpiler import Transpiler
 from jaclang.utils.test import TestCase
 
 
@@ -13,6 +13,6 @@ class ImportPassPassTests(TestCase):
 
     def test_pygen_jac_cli(self) -> None:
         """Basic test for pass."""
-        state = jac_file_to_pass(self.fixture_abs_path("base.jac"), "", ImportPass)
+        state = Transpiler.to_pass(self.fixture_abs_path("base.jac"), "", ImportPass)
         self.assertFalse(state.errors_had)
         self.assertIn("56", str(state.ir.to_dict()))

--- a/jaclang/jac/passes/blue/tests/test_sub_node_pass.py
+++ b/jaclang/jac/passes/blue/tests/test_sub_node_pass.py
@@ -1,7 +1,7 @@
 """Test sub node pass module."""
 
 from jaclang.jac.passes.blue import SubNodeTabPass
-from jaclang.jac.transpiler import jac_file_to_pass
+from jaclang.jac.transpiler import Transpiler
 from jaclang.utils.test import TestCase
 
 
@@ -14,7 +14,7 @@ class SubNodePassTests(TestCase):
 
     def test_sub_node_pass(self) -> None:
         """Basic test for pass."""
-        code_gen = jac_file_to_pass(
+        code_gen = Transpiler.to_pass(
             file_path=self.fixture_abs_path("../../../../../cli/cli.jac"),
             base_dir="",
             target=SubNodeTabPass,

--- a/jaclang/jac/passes/blue/tests/test_type_analyze_pass.py
+++ b/jaclang/jac/passes/blue/tests/test_type_analyze_pass.py
@@ -2,7 +2,7 @@
 import inspect
 
 from jaclang.jac.passes.blue import BluePygenPass, TypeAnalyzePass
-from jaclang.jac.transpiler import jac_file_to_pass
+from jaclang.jac.transpiler import Transpiler
 from jaclang.jac.utils import get_ast_nodes_as_snake_case as ast_snakes
 from jaclang.utils.test import TestCaseMicroSuite
 
@@ -16,7 +16,7 @@ class TypeAnalyzePassTests(TestCaseMicroSuite):
 
     def test_pygen_jac_cli(self) -> None:
         """Basic test for pass."""
-        code_gen = jac_file_to_pass(
+        code_gen = Transpiler.to_pass(
             self.fixture_abs_path("../../../../../cli/cli.jac"), target=BluePygenPass
         )
         # print(code_gen.ir.meta["py_code"])
@@ -45,7 +45,7 @@ class TypeAnalyzePassTests(TestCaseMicroSuite):
 
     def micro_suite_test(self, filename: str) -> None:
         """Parse micro jac file."""
-        ast = jac_file_to_pass(filename, "", target=BluePygenPass).ir
+        ast = Transpiler.to_pass(filename, "", target=BluePygenPass).ir
         typed_ast = TypeAnalyzePass(mod_path=filename, input_ir=ast).ir
         self.assertGreater(len(str(typed_ast.to_dict())), 10)
 

--- a/jaclang/jac/passes/purple/tests/test_purple_pygen_pass.py
+++ b/jaclang/jac/passes/purple/tests/test_purple_pygen_pass.py
@@ -2,7 +2,8 @@
 import io
 import sys
 
-from jaclang.jac.transpiler import transpile_jac_purple
+from jaclang.jac.transpiler import Transpiler
+from jaclang.jac.passes.purple import PurplePygenPass, pass_schedule as purple_pass_schedule
 from jaclang.utils.test import TestCaseMicroSuite
 
 
@@ -19,9 +20,7 @@ class PurplePygenPassTests(TestCaseMicroSuite):
 
         captured_output = io.StringIO()
         sys.stdout = captured_output
-        jac_purple_import(
-            "micro.simple_walk", self.fixture_abs_path("../../../../../../examples/")
-        )
+        jac_purple_import("micro.simple_walk", self.fixture_abs_path("../../../../../../examples/"))
         sys.stdout = sys.__stdout__
         stdout_value = captured_output.getvalue()
         self.assertEqual(
@@ -32,7 +31,7 @@ class PurplePygenPassTests(TestCaseMicroSuite):
 
     def micro_suite_test(self, filename: str) -> None:
         """Parse micro jac file."""
-        code_gen = transpile_jac_purple(filename, "")
+        code_gen = Transpiler.transpile(self.fixture_abs_path(filename), target=PurplePygenPass, pass_schedule=purple_pass_schedule)
         self.assertGreater(len(code_gen), 10)
 
 

--- a/jaclang/jac/passes/purple/tests/test_purple_pygen_pass.py
+++ b/jaclang/jac/passes/purple/tests/test_purple_pygen_pass.py
@@ -3,7 +3,10 @@ import io
 import sys
 
 from jaclang.jac.transpiler import Transpiler
-from jaclang.jac.passes.purple import PurplePygenPass, pass_schedule as purple_pass_schedule
+from jaclang.jac.passes.purple import (
+    PurplePygenPass,
+    pass_schedule as purple_pass_schedule,
+)
 from jaclang.utils.test import TestCaseMicroSuite
 
 
@@ -20,7 +23,9 @@ class PurplePygenPassTests(TestCaseMicroSuite):
 
         captured_output = io.StringIO()
         sys.stdout = captured_output
-        jac_purple_import("micro.simple_walk", self.fixture_abs_path("../../../../../../examples/"))
+        jac_purple_import(
+            "micro.simple_walk", self.fixture_abs_path("../../../../../../examples/")
+        )
         sys.stdout = sys.__stdout__
         stdout_value = captured_output.getvalue()
         self.assertEqual(
@@ -31,7 +36,11 @@ class PurplePygenPassTests(TestCaseMicroSuite):
 
     def micro_suite_test(self, filename: str) -> None:
         """Parse micro jac file."""
-        code_gen = Transpiler.transpile(self.fixture_abs_path(filename), target=PurplePygenPass, pass_schedule=purple_pass_schedule)
+        code_gen = Transpiler.transpile(
+            self.fixture_abs_path(filename),
+            target=PurplePygenPass,
+            pass_schedule=purple_pass_schedule,
+        )
         self.assertGreater(len(code_gen), 10)
 
 

--- a/jaclang/jac/transpiler.py
+++ b/jaclang/jac/transpiler.py
@@ -11,6 +11,7 @@ from jaclang.jac.transform import Transform
 
 T = TypeVar("T", bound=Pass)
 
+
 class Transpiler:
     @staticmethod
     def _to_parse_tree(file_path: str, base_dir: str) -> Transform:
@@ -21,26 +22,44 @@ class Transpiler:
                 mod_path=file_path, input_ir=lex.ir, base_path=base_dir, prior=lex
             )
             return prse
-    
+
     @staticmethod
-    def to_pass(file_path: str, base_dir: str = '', target: Type[T] = BluePygenPass, pass_schedule: List[Type[T]] = blue_pass_schedule)-> T:
+    def to_pass(
+        file_path: str,
+        base_dir: str = "",
+        target: Type[T] = BluePygenPass,
+        pass_schedule: List[Type[T]] = blue_pass_schedule,
+    ) -> T:
         """Convert a Jac file to an AST."""
         ast_ret = Transpiler._to_parse_tree(file_path, base_dir)
         for i in pass_schedule:
             if i == target:
                 break
             ast_ret = i(
-                mod_path=file_path, input_ir=ast_ret.ir, base_path=base_dir, prior=ast_ret
+                mod_path=file_path,
+                input_ir=ast_ret.ir,
+                base_path=base_dir,
+                prior=ast_ret,
             )
         ast_ret = target(
             mod_path=file_path, input_ir=ast_ret.ir, base_path=base_dir, prior=ast_ret
         )
         return ast_ret
-    
+
     @staticmethod
-    def transpile(file_path: str, base_dir: str = '', pass_schedule: List[Type[T]] = blue_pass_schedule, target: Type[T] = BluePygenPass) -> Transform:
+    def transpile(
+        file_path: str,
+        base_dir: str = "",
+        pass_schedule: List[Type[T]] = blue_pass_schedule,
+        target: Type[T] = BluePygenPass,
+    ) -> Transform:
         """Transpiler Jac file and return python code as string."""
-        code = Transpiler.to_pass(file_path=file_path, base_dir=base_dir, target=target, pass_schedule = pass_schedule)
+        code = Transpiler.to_pass(
+            file_path=file_path,
+            base_dir=base_dir,
+            target=target,
+            pass_schedule=pass_schedule,
+        )
         if isinstance(code.ir, ast.Module):
             return code.ir.meta["py_code"]
         else:

--- a/jaclang/jac/transpiler.py
+++ b/jaclang/jac/transpiler.py
@@ -1,26 +1,58 @@
 """Transpilation functions."""
-from typing import Type, TypeVar
+from typing import Type, TypeVar, List
 
 import jaclang.jac.absyntree as ast
 from jaclang.jac.parser import JacLexer
 from jaclang.jac.parser import JacParser
 from jaclang.jac.passes import Pass
-from jaclang.jac.passes.blue import BluePygenPass, pass_schedule
+from jaclang.jac.passes.blue import BluePygenPass, pass_schedule as blue_pass_schedule
 from jaclang.jac.transform import Transform
 
 
 T = TypeVar("T", bound=Pass)
 
-
-def jac_file_to_parse_tree(file_path: str, base_dir: str) -> Transform:
-    """Convert a Jac file to an AST."""
-    with open(file_path) as file:
-        lex = JacLexer(mod_path=file_path, input_ir=file.read(), base_path=base_dir)
-        prse = JacParser(
-            mod_path=file_path, input_ir=lex.ir, base_path=base_dir, prior=lex
+class Transpiler:
+    def _to_parse_tree(self, file_path: str, base_dir: str) -> Transform:
+        """Convert a Jac file to an AST."""
+        with open(file_path) as file:
+            lex = JacLexer(mod_path=file_path, input_ir=file.read(), base_path=base_dir)
+            prse = JacParser(
+                mod_path=file_path, input_ir=lex.ir, base_path=base_dir, prior=lex
+            )
+            return prse
+    
+    def to_pass(self, file_path: str, base_dir: str, target: Type[T], pass_schedule: List[Type[T]])-> T:
+        """Convert a Jac file to an AST."""
+        ast_ret = self._to_parse_tree(file_path, base_dir)
+        for i in pass_schedule:
+            if i == target:
+                break
+            ast_ret = i(
+                mod_path=file_path, input_ir=ast_ret.ir, base_path=base_dir, prior=ast_ret
+            )
+        ast_ret = target(
+            mod_path=file_path, input_ir=ast_ret.ir, base_path=base_dir, prior=ast_ret
         )
-        return prse
+        return ast_ret
 
+    def __call__(self, file_path: str, base_dir: str, pass_schedule: List[Type[T]] = blue_pass_schedule, target: Type[T] = BluePygenPass) -> Transform:
+        """Transpiler Jac file and return python code as string."""
+        code = self.to_pass(file_path=file_path, base_dir=base_dir, target=target, pass_schedule = pass_schedule)
+        if isinstance(code.ir, ast.Module):
+            return code.ir.meta["py_code"]
+        else:
+            raise code.gen_exception("Transpilation of Jac file failed.")
+
+
+
+def jac_file_to_parse_tree(self, file_path: str, base_dir: str) -> Transform:
+        """Convert a Jac file to an AST."""
+        with open(file_path) as file:
+            lex = JacLexer(mod_path=file_path, input_ir=file.read(), base_path=base_dir)
+            prse = JacParser(
+                mod_path=file_path, input_ir=lex.ir, base_path=base_dir, prior=lex
+            )
+            return prse
 
 def transpile_jac_blue(file_path: str, base_dir: str) -> str:
     """Transpiler Jac file and return python code as string."""
@@ -53,7 +85,7 @@ def jac_file_to_pass(
     file_path: str,
     base_dir: str = "",
     target: Type[T] = BluePygenPass,
-    schedule: list[Type[T]] = pass_schedule,
+    schedule: list[Type[T]] = blue_pass_schedule,
 ) -> T:
     """Convert a Jac file to an AST."""
     ast_ret = jac_file_to_parse_tree(file_path, base_dir)

--- a/jaclang/jac/transpiler.py
+++ b/jaclang/jac/transpiler.py
@@ -12,7 +12,8 @@ from jaclang.jac.transform import Transform
 T = TypeVar("T", bound=Pass)
 
 class Transpiler:
-    def _to_parse_tree(self, file_path: str, base_dir: str) -> Transform:
+    @staticmethod
+    def _to_parse_tree(file_path: str, base_dir: str) -> Transform:
         """Convert a Jac file to an AST."""
         with open(file_path) as file:
             lex = JacLexer(mod_path=file_path, input_ir=file.read(), base_path=base_dir)
@@ -21,9 +22,10 @@ class Transpiler:
             )
             return prse
     
-    def to_pass(self, file_path: str, base_dir: str, target: Type[T], pass_schedule: List[Type[T]])-> T:
+    @staticmethod
+    def to_pass(file_path: str, base_dir: str = '', target: Type[T] = BluePygenPass, pass_schedule: List[Type[T]] = blue_pass_schedule)-> T:
         """Convert a Jac file to an AST."""
-        ast_ret = self._to_parse_tree(file_path, base_dir)
+        ast_ret = Transpiler._to_parse_tree(file_path, base_dir)
         for i in pass_schedule:
             if i == target:
                 break
@@ -34,68 +36,12 @@ class Transpiler:
             mod_path=file_path, input_ir=ast_ret.ir, base_path=base_dir, prior=ast_ret
         )
         return ast_ret
-
-    def __call__(self, file_path: str, base_dir: str, pass_schedule: List[Type[T]] = blue_pass_schedule, target: Type[T] = BluePygenPass) -> Transform:
+    
+    @staticmethod
+    def transpile(file_path: str, base_dir: str = '', pass_schedule: List[Type[T]] = blue_pass_schedule, target: Type[T] = BluePygenPass) -> Transform:
         """Transpiler Jac file and return python code as string."""
-        code = self.to_pass(file_path=file_path, base_dir=base_dir, target=target, pass_schedule = pass_schedule)
+        code = Transpiler.to_pass(file_path=file_path, base_dir=base_dir, target=target, pass_schedule = pass_schedule)
         if isinstance(code.ir, ast.Module):
             return code.ir.meta["py_code"]
         else:
             raise code.gen_exception("Transpilation of Jac file failed.")
-
-
-
-def jac_file_to_parse_tree(self, file_path: str, base_dir: str) -> Transform:
-        """Convert a Jac file to an AST."""
-        with open(file_path) as file:
-            lex = JacLexer(mod_path=file_path, input_ir=file.read(), base_path=base_dir)
-            prse = JacParser(
-                mod_path=file_path, input_ir=lex.ir, base_path=base_dir, prior=lex
-            )
-            return prse
-
-def transpile_jac_blue(file_path: str, base_dir: str) -> str:
-    """Transpiler Jac file and return python code as string."""
-    code = jac_file_to_pass(
-        file_path=file_path, base_dir=base_dir, target=BluePygenPass
-    )
-    if isinstance(code.ir, ast.Module):
-        return code.ir.meta["py_code"]
-    else:
-        raise code.gen_exception("Transpilation of Jac file failed.")
-
-
-def transpile_jac_purple(file_path: str, base_dir: str) -> str:
-    """Transpiler Jac file and return python code as string."""
-    from jaclang.jac.passes.purple import pass_schedule, PurplePygenPass
-
-    code = jac_file_to_pass(
-        file_path=file_path,
-        base_dir=base_dir,
-        target=PurplePygenPass,
-        schedule=pass_schedule,
-    )
-    if isinstance(code.ir, ast.Module):
-        return code.ir.meta["py_code"]
-    else:
-        raise code.gen_exception("Transpilation of Jac file failed.")
-
-
-def jac_file_to_pass(
-    file_path: str,
-    base_dir: str = "",
-    target: Type[T] = BluePygenPass,
-    schedule: list[Type[T]] = blue_pass_schedule,
-) -> T:
-    """Convert a Jac file to an AST."""
-    ast_ret = jac_file_to_parse_tree(file_path, base_dir)
-    for i in schedule:
-        if i == target:
-            break
-        ast_ret = i(
-            mod_path=file_path, input_ir=ast_ret.ir, base_path=base_dir, prior=ast_ret
-        )
-    ast_ret = target(
-        mod_path=file_path, input_ir=ast_ret.ir, base_path=base_dir, prior=ast_ret
-    )
-    return ast_ret


### PR DESCRIPTION
Transpiler Class
has 3 static methods
1. to_pass - similar to jacfile_to_pass
2. transpile - alternative to separate blue and purple transpilers
3. _to_parse_tree similar to jac_file_to_parse_tree

Main Updates - Importer (now can pass "blue" or purple" to import_jac_module to simulate the jac_blue_import and jac_purple_import