### PR TITLE
WIP: feat: py_importer & general_importer

### DIFF
--- a/jaclang/__init__.py
+++ b/jaclang/__init__.py
@@ -5,11 +5,15 @@ import sys
 
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "vendor"))
 
+from jaclang.core.importer import general_importer
+
 from jaclang.plugin.default import JacFeatureDefaults  # noqa: E402
 from jaclang.plugin.feature import JacFeature, pm  # noqa: E402
-from jaclang.vendor import lark  # noqa: E402
-from jaclang.vendor import mypy  # noqa: E402
-from jaclang.vendor import pluggy  # noqa: E402
+from jaclang.vendor import (
+    lark,  # noqa: E402
+    mypy,  # noqa: E402
+    pluggy,  # noqa: E402
+)
 
 jac_import = JacFeature.jac_import
 

--- a/jaclang/core/importer.py
+++ b/jaclang/core/importer.py
@@ -1,5 +1,6 @@
 """Special Imports for Jac Code."""
 
+import importlib
 import marshal
 import sys
 import types
@@ -10,6 +11,16 @@ from jaclang.compiler.absyntree import Module
 from jaclang.compiler.compile import compile_jac
 from jaclang.compiler.constant import Constants as Con
 from jaclang.utils.log import logging
+
+
+def py_importer(target: str, base_path: str) -> types.ModuleType:
+    """Use importlib to import a Python module."""
+    print(f"Importing {target}")
+    sys.path.append(base_path)
+    res = importlib.import_module(target)
+    sys.path.remove(base_path)
+    return res
+
 
 
 def jac_importer(
@@ -93,3 +104,9 @@ def jac_importer(
         sys.path.remove(caller_dir)
 
     return module
+
+def general_importer(target: str, base_path: str):
+    try:
+        return py_importer(target, base_path)
+    except ModuleNotFoundError:
+        return jac_importer(target, base_path)


### PR DESCRIPTION
- Add a function that imports a python package (or a Jaclang package as a fall back) using the function called general_importer
- Talked to Jason, the feature is fully covered by #236 but this is my first work on the new jac system. So I chose an easy one.