### PR TITLE
feat: node types in edge ref lists

### DIFF
--- a/jaclang/compiler/absyntree.py
+++ b/jaclang/compiler/absyntree.py
@@ -1764,7 +1764,7 @@ class EdgeRefTrailer(Expr):
 
     def __init__(
         self,
-        chain: list[Expr],
+        chain: list[Expr | FilterCompr],
         edges_only: bool,
         kid: Sequence[AstNode],
     ) -> None:

--- a/jaclang/compiler/jac.lark
+++ b/jaclang/compiler/jac.lark
@@ -416,7 +416,7 @@ kw_expr_list: (kw_expr_list COMMA)? kw_expr
 kw_expr: any_ref EQ expression | STAR_POW expression
 
 // Data Spatial References
-edge_ref_chain: (EDGE_OP|NODE_OP)? LSQUARE expression? (edge_op_ref expression?)+ RSQUARE
+edge_ref_chain: (EDGE_OP|NODE_OP)? LSQUARE expression? (edge_op_ref (filter_compr | expression)?)+ RSQUARE
 edge_op_ref: edge_any | edge_from | edge_to
 edge_to: ARROW_R | ARROW_R_P1 typed_filter_compare_list ARROW_R_P2
 edge_from: ARROW_L | ARROW_L_P1 typed_filter_compare_list ARROW_L_P2

--- a/jaclang/compiler/parser.py
+++ b/jaclang/compiler/parser.py
@@ -3110,9 +3110,10 @@ class JacParser(Pass):
         def edge_ref_chain(self, kid: list[ast.AstNode]) -> ast.EdgeRefTrailer:
             """Grammar rule.
 
-            edge_ref_chain: (EDGE_OP|NODE_OP)? LSQUARE expression? (edge_op_ref expression?)+ RSQUARE
+            edge_ref_chain: (EDGE_OP|NODE_OP)? LSQUARE expression?
+                (edge_op_ref (NODE_OP? expression)?)+ RSQUARE
             """
-            valid_chain = [i for i in kid if isinstance(i, (ast.Expr))]
+            valid_chain = [i for i in kid if isinstance(i, (ast.Expr, ast.FilterCompr))]
             return self.nu(
                 ast.EdgeRefTrailer(
                     chain=valid_chain,

--- a/jaclang/tests/fixtures/edge_node_walk.jac
+++ b/jaclang/tests/fixtures/edge_node_walk.jac
@@ -42,5 +42,5 @@ with entry {
     print([<root>-:Edge_c:->]);
     print([<root>-:Edge_a:->-:Edge_b:->]);
     print([<root>-:Edge_a:->-:Edge_b:->-:Edge_c:->]);
-    print([<root>-:Edge_a:->-:Edge_b:->-:Edge_c:->:n:node_b]);
+    print([<root>-:Edge_a:->-:Edge_b:->-:Edge_c:->(`?node_b)]);
 }

--- a/jaclang/tests/fixtures/edge_node_walk.jac
+++ b/jaclang/tests/fixtures/edge_node_walk.jac
@@ -1,0 +1,46 @@
+walker creator {
+    can create with `<root> entry;
+}
+
+node node_a {
+    has val: int;
+}
+
+node node_b {
+    has val: int;
+}
+
+edge Edge_a {
+    has value: int = 10;
+}
+
+edge Edge_b {
+    has value1: int = 20;
+}
+
+edge Edge_c {
+    has value2: int = 30;
+}
+
+:walker:creator:can:create {
+    for i=0 to i<2 by i+=1  {
+        <here> +:Edge_c:value2=30:+> (node_a(val=i + 1));
+        visit [-->];
+    }
+    <here> +:Edge_a:value=10:+> (end := node_a(val=i + 10));
+    end +:Edge_b:value1=20:+> (last := node_a(val=i + 20));
+    for j=0 to j<2 by j+=1  {
+        last +:Edge_c:value2=40:+> (node_a(val=i + 40));
+        last +:Edge_c:value2=40:+> (node_b(val=i + 40));
+    }
+}
+
+with entry {
+    print(<root> spawn creator());
+    print(<r>._jac_.gen_dot());
+    print([<root>-:Edge_a:->]);
+    print([<root>-:Edge_c:->]);
+    print([<root>-:Edge_a:->-:Edge_b:->]);
+    print([<root>-:Edge_a:->-:Edge_b:->-:Edge_c:->]);
+    print([<root>-:Edge_a:->-:Edge_b:->-:Edge_c:->:n:node_b]);
+}

--- a/jaclang/tests/test_language.py
+++ b/jaclang/tests/test_language.py
@@ -349,9 +349,8 @@ class JacLanguageTests(TestCase):
         jac_import("edge_node_walk", base_path=self.fixture_abs_path("./"))
         sys.stdout = sys.__stdout__
         stdout_value = captured_output.getvalue()
-        print(stdout_value)
         self.assertIn("creator()\n", stdout_value)
         self.assertIn("[node_a(val=12)]\n", stdout_value)
         self.assertIn("node_a(val=1)", stdout_value)
         self.assertIn("node_a(val=2)", stdout_value)
-        self.assertIn("[node_a(val=42), node_a(val=42)]\n", stdout_value)
+        self.assertIn("[node_b(val=42), node_b(val=42)]\n", stdout_value)

--- a/jaclang/tests/test_language.py
+++ b/jaclang/tests/test_language.py
@@ -340,3 +340,18 @@ class JacLanguageTests(TestCase):
             stdout_value,
         )
         self.assertIn("[MyObj(a=0), MyObj(a=1), MyObj(a=2)]\n", stdout_value)
+
+    def test_edge_node_walk(self) -> None:
+        """Test walking through edges and nodes."""
+        construct.root._jac_.edges.clear()
+        captured_output = io.StringIO()
+        sys.stdout = captured_output
+        jac_import("edge_node_walk", base_path=self.fixture_abs_path("./"))
+        sys.stdout = sys.__stdout__
+        stdout_value = captured_output.getvalue()
+        print(stdout_value)
+        self.assertIn("creator()\n", stdout_value)
+        self.assertIn("[node_a(val=12)]\n", stdout_value)
+        self.assertIn("node_a(val=1)", stdout_value)
+        self.assertIn("node_a(val=2)", stdout_value)
+        self.assertIn("[node_a(val=42), node_a(val=42)]\n", stdout_value)


### PR DESCRIPTION
Adding syntax for allowing not just node objects, but also node types (that will function as a filter) on edge ref syntax. 

```
[--> :n:NodeType]
```

would then give me all of the nodes connected to here that is of type NodeType. 