### PR TITLE
[EDGE]: Implement in/out seperation

### DIFF
--- a/jaclang/compiler/constant.py
+++ b/jaclang/compiler/constant.py
@@ -234,3 +234,10 @@ class Tokens(str, Enum):
     def __str__(self) -> str:
         """Return the string representation of the token."""
         return self.value
+
+
+class EdgeDirGroup:
+    """Edge direction group."""
+
+    OUT: list[EdgeDir] = [EdgeDir.OUT, EdgeDir.ANY]
+    IN: list[EdgeDir] = [EdgeDir.IN, EdgeDir.ANY]

--- a/jaclang/compiler/passes/main/pyast_gen_pass.py
+++ b/jaclang/compiler/passes/main/pyast_gen_pass.py
@@ -1786,7 +1786,22 @@ class PyastGenPass(Pass):
                             node.left.gen.py_ast[0],
                             node.right.gen.py_ast[0],
                             self.sync(
-                                ast3.Constant(value=node.op.edge_spec.edge_dir.name)
+                                ast3.Attribute(
+                                    value=self.sync(
+                                        ast3.Attribute(
+                                            value=self.sync(
+                                                ast3.Name(
+                                                    id=Con.JAC_FEATURE.value,
+                                                    ctx=ast3.Load(),
+                                                )
+                                            ),
+                                            attr="EdgeDir",
+                                            ctx=ast3.Load(),
+                                        )
+                                    ),
+                                    attr=node.op.edge_spec.edge_dir.name,
+                                    ctx=ast3.Load(),
+                                )
                             ),
                             (
                                 node.op.edge_spec.filter_cond.gen.py_ast[0]

--- a/jaclang/core/utils.py
+++ b/jaclang/core/utils.py
@@ -17,12 +17,10 @@ def collect_node_connections(
     """Nodes and edges representing the graph are collected in visited_nodes and connections."""
     if current_node not in visited_nodes:
         visited_nodes.add(current_node)
-        edges = current_node.edges
-
-        for edge_ in edges:
-            target = edge_._jac_.target
+        for edge in [*current_node.edges_in, *current_node.edges_out]:
+            target = edge._jac_.target
             if target:
                 connections.add(
-                    (current_node.obj, target._jac_.obj, edge_.__class__.__name__)
+                    (current_node.obj, target._jac_.obj, edge.__class__.__name__)
                 )
                 collect_node_connections(target._jac_, visited_nodes, connections)

--- a/jaclang/tests/fixtures/edge_ops.jac
+++ b/jaclang/tests/fixtures/edge_ops.jac
@@ -22,7 +22,7 @@ edge MyEdge {
             for j=0 to j<3 by j+=1  {
                 end +:MyEdge:val=random.randint(1, 15), val2=random.randint(1, 5):+> node_a(value=j + 10);
             }
-            print([(i.val, i.val2) for i in end._jac_.edges if isinstance(i, MyEdge)]);
+            print([(i.val, i.val2) for i in (end._jac_.edges_in + end._jac_.edges_out) if isinstance(i, MyEdge)]);
         }
     }
     for i=0 to i<3 by i+=1  {

--- a/jaclang/tests/test_language.py
+++ b/jaclang/tests/test_language.py
@@ -107,7 +107,7 @@ class JacLanguageTests(TestCase):
 
     def test_ignore(self) -> None:
         """Parse micro jac file."""
-        construct.root._jac_.edges.clear()
+        construct.root._jac_.clear_edges()
         captured_output = io.StringIO()
         sys.stdout = captured_output
         jac_import("ignore", base_path=self.fixture_abs_path("./"))
@@ -201,7 +201,7 @@ class JacLanguageTests(TestCase):
 
     def test_deep_imports(self) -> None:
         """Parse micro jac file."""
-        construct.root._jac_.edges.clear()
+        construct.root._jac_.clear_edges()
         captured_output = io.StringIO()
         sys.stdout = captured_output
         jac_import("deep_import", base_path=self.fixture_abs_path("./"))
@@ -211,7 +211,7 @@ class JacLanguageTests(TestCase):
 
     def test_has_lambda_goodness(self) -> None:
         """Test has lambda_goodness."""
-        construct.root._jac_.edges.clear()
+        construct.root._jac_.clear_edges()
         captured_output = io.StringIO()
         sys.stdout = captured_output
         jac_import("has_goodness", base_path=self.fixture_abs_path("./"))
@@ -222,7 +222,7 @@ class JacLanguageTests(TestCase):
 
     def test_conn_assign_on_edges(self) -> None:
         """Test conn assign on edges."""
-        construct.root._jac_.edges.clear()
+        construct.root._jac_.clear_edges()
         captured_output = io.StringIO()
         sys.stdout = captured_output
         jac_import("edge_ops", base_path=self.fixture_abs_path("./"))
@@ -234,7 +234,7 @@ class JacLanguageTests(TestCase):
 
     def test_disconnect(self) -> None:
         """Test conn assign on edges."""
-        construct.root._jac_.edges.clear()
+        construct.root._jac_.clear_edges()
         captured_output = io.StringIO()
         sys.stdout = captured_output
         jac_import("disconn", base_path=self.fixture_abs_path("./"))
@@ -249,7 +249,7 @@ class JacLanguageTests(TestCase):
 
     def test_simple_archs(self) -> None:
         """Test conn assign on edges."""
-        construct.root._jac_.edges.clear()
+        construct.root._jac_.clear_edges()
         captured_output = io.StringIO()
         sys.stdout = captured_output
         jac_import("simple_archs", base_path=self.fixture_abs_path("./"))
@@ -260,7 +260,7 @@ class JacLanguageTests(TestCase):
 
     def test_edge_walk(self) -> None:
         """Test walking through edges."""
-        construct.root._jac_.edges.clear()
+        construct.root._jac_.clear_edges()
         captured_output = io.StringIO()
         sys.stdout = captured_output
         jac_import("edges_walk", base_path=self.fixture_abs_path("./"))
@@ -274,7 +274,7 @@ class JacLanguageTests(TestCase):
 
     def test_impl_grab(self) -> None:
         """Test walking through edges."""
-        construct.root._jac_.edges.clear()
+        construct.root._jac_.clear_edges()
         captured_output = io.StringIO()
         sys.stdout = captured_output
         jac_import("impl_grab", base_path=self.fixture_abs_path("./"))
@@ -284,7 +284,7 @@ class JacLanguageTests(TestCase):
 
     def test_tuple_of_tuple_assign(self) -> None:
         """Test walking through edges."""
-        construct.root._jac_.edges.clear()
+        construct.root._jac_.clear_edges()
         captured_output = io.StringIO()
         sys.stdout = captured_output
         jac_import("tuplytuples", base_path=self.fixture_abs_path("./"))
@@ -297,7 +297,7 @@ class JacLanguageTests(TestCase):
 
     def test_deferred_field(self) -> None:
         """Test walking through edges."""
-        construct.root._jac_.edges.clear()
+        construct.root._jac_.clear_edges()
         captured_output = io.StringIO()
         sys.stdout = captured_output
         jac_import("deferred_field", base_path=self.fixture_abs_path("./"))
@@ -310,7 +310,7 @@ class JacLanguageTests(TestCase):
 
     def test_with_contexts(self) -> None:
         """Test walking through edges."""
-        construct.root._jac_.edges.clear()
+        construct.root._jac_.clear_edges()
         captured_output = io.StringIO()
         sys.stdout = captured_output
         jac_import("with_context", base_path=self.fixture_abs_path("./"))
@@ -343,7 +343,7 @@ class JacLanguageTests(TestCase):
 
     def test_edge_node_walk(self) -> None:
         """Test walking through edges and nodes."""
-        construct.root._jac_.edges.clear()
+        construct.root._jac_.clear_edges()
         captured_output = io.StringIO()
         sys.stdout = captured_output
         jac_import("edge_node_walk", base_path=self.fixture_abs_path("./"))


### PR DESCRIPTION
Before we have this kind of structure for NodeAnchor.edges
> dict[EdgeDir, list[EdgeArchitype]]

On latest main, it was changed to
> list[EdgeArchitype]

The concern is on main branch approach, every time we need to filter out edges we will always iterate the whole edge list. The old approach has segregate based on their direction. Since we always know which direction to check, it will be faster to know which edge group to be included in the iteration. 

On this PR, I just set it directly on NodeAnchor instead of putting in a single field and group it on a dictionary