### PR TITLE
[DOC] mkdocs README file addition

### DIFF
--- a/support/jac-lang.org/README.md
+++ b/support/jac-lang.org/README.md
@@ -1,0 +1,24 @@
+# Contributing to Documentation @ jac-lang.org
+
+## How to find, add and change the documentation architecture
+
+
+
+## Running a local preview instance of the documentation
+
+To open a preview of the mkdocs server locally, following steps should be followed.
+
+1. Install Jaclang from source.
+
+    ```bash
+    pip install -e .
+    ```
+
+2. Bash the following lines to initiate the server.
+
+    ```bash
+    cd support/jac-lang.org/
+    mkdocs serve
+    ```
+
+3. When prompted open the server from a web browser or the VS Code editor itself.

--- a/support/jac-lang.org/README.md
+++ b/support/jac-lang.org/README.md
@@ -23,16 +23,16 @@ nav:
 
 To open a preview of the mkdocs server locally, following steps should be followed.
 
-1. Install Jaclang from source.
+1. Install necessaries such as pygments and jaclang syntax highlighting from source.
 
     ```bash
+    cd support/jac-lang.org/
     pip install -e .
     ```
 
 2. Bash the following lines to initiate the server.
 
     ```bash
-    cd support/jac-lang.org/
     mkdocs serve
     ```
 

--- a/support/jac-lang.org/README.md
+++ b/support/jac-lang.org/README.md
@@ -2,7 +2,22 @@
 
 ## How to find, add and change the documentation architecture
 
+When adding content to the documentations maintain the document structure used in [docs](./docs/) folder. To include a new file or content into the documentation, edit the [mkdocs.yml](./mkdocs.yml) file.
 
+As an example consider adding a new 'example.md' file residing in file path './docs/learn' in to the [mkdocs.yml](./mkdocs.yml) file, under the 'for_contributors' subsection. The file should change as following.
+
+```yaml
+...
+nav:
+    ...
+    - ~/learn$:
+      ...
+      - ~/for_contributors:
+        ...
+        - 'learn/example.md'
+      ...
+...
+```
 
 ## Running a local preview instance of the documentation
 


### PR DESCRIPTION
**Changes**
- README.md file added within ./support/jac-lang.org/ folder

**Included**
- Guide on how to use the mkdocs package for running a local server for editing preview.

- How to add new pages/sections to the existing documentation.