### PR TITLE
Normalize Enhancement - 03 

### DIFF
--- a/jaclang/compiler/absyntree.py
+++ b/jaclang/compiler/absyntree.py
@@ -2636,7 +2636,6 @@ class TupleVal(AtomExpr):
             and self.parent.parent
             and isinstance(self.parent.parent.parent, FuncSignature)
         )
-        print(in_ret_type)
         new_kid: list[AstNode] = (
             [
                 self.gen_token(Tok.LPAREN),

--- a/jaclang/compiler/absyntree.py
+++ b/jaclang/compiler/absyntree.py
@@ -2628,14 +2628,28 @@ class TupleVal(AtomExpr):
         res = True
         if deep:
             res = self.values.normalize(deep) if self.values else res
-        new_kid: list[AstNode] = [
-            self.gen_token(Tok.LPAREN),
-        ]
+        in_ret_type = (
+            self.parent
+            and isinstance(self.parent, IndexSlice)
+            and self.parent
+            and isinstance(self.parent.parent, AtomTrailer)
+            and self.parent.parent
+            and isinstance(self.parent.parent.parent, FuncSignature)
+        )
+        print(in_ret_type)
+        new_kid: list[AstNode] = (
+            [
+                self.gen_token(Tok.LPAREN),
+            ]
+            if not in_ret_type
+            else []
+        )
         if self.values:
             new_kid.append(self.values)
             if len(self.values.items) < 2:
                 new_kid.append(self.gen_token(Tok.COMMA))
-        new_kid.append(self.gen_token(Tok.RPAREN))
+        if not in_ret_type:
+            new_kid.append(self.gen_token(Tok.RPAREN))
         AstNode.set_kids(self, nodes=new_kid)
         return res
 

--- a/jaclang/compiler/parser.py
+++ b/jaclang/compiler/parser.py
@@ -1772,6 +1772,7 @@ class JacParser(Pass):
             type_tag = chomp[-1] if isinstance(chomp[-1], ast.SubTag) else None
             if not value:
                 semstr = chomp[2] if len(chomp) > 2 else None
+                chomp = chomp[:-2] if semstr else chomp
             else:
                 if type_tag:
                     chomp = chomp[:-1]


### PR DESCRIPTION
This PR is a continuation of https://github.com/Jaseci-Labs/jaclang/pull/322. 

The changes introduced in this PR aim to enhance the normalization behavior.
- Return Type issue in  jaclang/tests/fixtures/with_llm_method.jac
-  Glob assignemnt issue in  jaclang/tests/fixtures/semstr.jac

These improvements will contribute to better conversion between the Python AST and the Jac AST.