### PR TITLE
Pytest Version Fix

### DIFF
--- a/.github/workflows/run_pytest.yml
+++ b/.github/workflows/run_pytest.yml
@@ -22,7 +22,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -e .
-        pip install pytest
+        pip install pytest==8.1.1
         pip install pygame
 
     - name: Run tests


### PR DESCRIPTION
Pin pytest version to 8.1.1

pytest released 8.2.0 on April 27th, which seems to break the test setup. https://github.com/Jaseci-Labs/jaclang/actions/runs/8868388838/job/24347918089