### PR TITLE
Correct jac module path

### DIFF
--- a/jaclang/plugin/default.py
+++ b/jaclang/plugin/default.py
@@ -85,7 +85,11 @@ class JacFeatureDefaults:
         for i in on_entry + on_exit:
             i.resolve(cls)
         if not issubclass(cls, arch_base):
+            # Saving the module path and reassign it after creating cls
+            # So the jac modules are part of the correct module
+            cur_module = cls.__module__
             cls = type(cls.__name__, (cls, arch_base), {})
+            cls.__module__ = cur_module
             cls._jac_entry_funcs_ = on_entry  # type: ignore
             cls._jac_exit_funcs_ = on_exit  # type: ignore
         else:


### PR DESCRIPTION
Saving and re-assign `__module__` for custom jac module in `make_architype`