### PR TITLE
[Support] MTLLM - Model Finetuning and Synthetic Jac Code Generation Scripts

### DIFF
--- a/support/mtllm_finetune/README.md
+++ b/support/mtllm_finetune/README.md
@@ -1,0 +1,1 @@
+# Finetuning Scripts for MTLLM TInyLLama 1.1B Model

--- a/support/mtllm_finetune/merge_n_push.py
+++ b/support/mtllm_finetune/merge_n_push.py
@@ -1,0 +1,69 @@
+"""Merge the LoRA with the Base Model and push to the Hugging Face Hub."""
+
+import argparse
+import os
+
+from huggingface_hub import login
+
+from peft import PeftModel
+
+import torch
+
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+import utils.constants as cons
+
+
+def merge_n_push(args: argparse.Namespace) -> None:
+    """Merge the LoRA with the Base Model and push to the Hugging Face Hub."""
+    # Merging the LoRA with the base model
+    model = AutoModelForCausalLM.from_pretrained(
+        args.base_model_id,
+        torch_dtype=torch.float16,
+        load_in_8bit=False,
+        device_map="auto",
+        trust_remote_code=True,
+    )
+    tokenizer = AutoTokenizer.from_pretrained(args.base_model_id)
+    peft_model = PeftModel.from_pretrained(
+        model, args.checkpoint_dir, from_transformers=True, device_map="auto"
+    )
+    model = peft_model.merge_and_unload()
+    model.save_pretrained(os.path.join(args.output_model_name, "merged"))
+    tokenizer.save_pretrained(os.path.join(args.output_model_name, "merged"))
+
+    # Pushing the model to the Hugging Face Hub
+    model.push_to_hub(
+        f"{args.hf_username}/{args.output_model_name}", token=args.hf_token
+    )
+    tokenizer.push_to_hub(
+        f"{args.hf_username}/{args.output_model_name}", token=args.hf_token
+    )
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "--base_model_id", type=str, default=cons.HF_MODEL, help="Base model ID"
+    )
+    parser.add_argument(
+        "--output_model_name",
+        type=str,
+        default=cons.OUTPUT_MODEL,
+        help="Output model name",
+    )
+    parser.add_argument(
+        "--checkpoint_dir", type=str, required=True, help="Model Checkpoint directory"
+    )
+    parser.add_argument(
+        "--hf_username", type=str, required=True, help="Hugging Face username"
+    )
+    parser.add_argument(
+        "--hf_token", type=str, required=True, help="Hugging Face API token"
+    )
+
+    args = parser.parse_args()
+
+    login(args.hf_token)
+    merge_n_push(args)

--- a/support/mtllm_finetune/requirements.txt
+++ b/support/mtllm_finetune/requirements.txt
@@ -1,0 +1,6 @@
+accelerate
+peft
+bitsandbytes
+transformers
+trl
+loguru

--- a/support/mtllm_finetune/train.py
+++ b/support/mtllm_finetune/train.py
@@ -1,0 +1,83 @@
+"""Training script for the MTLLM Model finetuning task."""
+
+import argparse
+
+from huggingface_hub import login
+
+from peft import LoraConfig
+
+from transformers import TrainingArguments
+
+from trl import SFTTrainer
+
+import utils.constants as cons
+from utils.dataset import prepare_train_data
+from utils.model import get_model_tokenizer
+
+
+def train(args: argparse.Namespace) -> None:
+    """Train the model on the given dataset."""
+    train_data = prepare_train_data(args.dataset)
+    model, tokenizer = get_model_tokenizer(args.model_id)
+    peft_config = LoraConfig(
+        r=8, lora_alpha=16, lora_dropout=0.05, bias="none", task_type="CAUSAL_LM"
+    )
+    training_args = TrainingArguments(
+        output_dir=args.output_model_name,
+        per_device_train_batch_size=16,
+        gradient_accumulation_steps=4,
+        optim="paged_adamw_32bit",
+        learning_rate=args.lr,
+        lr_scheduler_type="cosine",
+        save_strategy="epoch",
+        logging_steps=10,
+        num_train_epochs=args.max_num_epochs,
+        max_steps=250,
+        fp16=True,
+    )
+    trainer = SFTTrainer(
+        model=model,
+        train_dataset=train_data,
+        peft_config=peft_config,
+        dataset_text_field="text",
+        args=training_args,
+        tokenizer=tokenizer,
+        packing=False,
+        max_seq_length=1024,
+    )
+    trainer.train()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--dataset", type=str, default=cons.HF_DATASET, help="Dataset ID to train on"
+    )
+    parser.add_argument(
+        "--model_id", type=str, default=cons.HF_MODEL, help="Model ID to train"
+    )
+    parser.add_argument(
+        "--output_model_name",
+        type=str,
+        default=cons.OUTPUT_MODEL,
+        help="Output model name",
+    )
+    parser.add_argument(
+        "--hf_token", type=str, required=True, help="Hugging Face API token"
+    )
+
+    parser.add_argument(
+        "--max_num_epochs",
+        type=int,
+        default=cons.MAX_NUM_EPOCHS,
+        help="Maximum number of epochs to train for",
+    )
+    parser.add_argument(
+        "--lr", type=float, default=cons.LR, help="Learning rate for the model"
+    )
+
+    args = parser.parse_args()
+
+    login(args.hf_token)
+
+    train(args)

--- a/support/mtllm_finetune/utils/constants.py
+++ b/support/mtllm_finetune/utils/constants.py
@@ -1,0 +1,8 @@
+"""Constants."""
+
+HF_DATASET = "jaseci/mtllm"
+HF_MODEL = "TinyLlama/TinyLlama-1.1B-Chat-v1.0"
+OUTPUT_MODEL = "mtllm-tinyllama-1.1b-chat-v1.0"
+
+MAX_NUM_EPOCHS = 3
+LR = 2e-4

--- a/support/mtllm_finetune/utils/dataset.py
+++ b/support/mtllm_finetune/utils/dataset.py
@@ -1,0 +1,19 @@
+"""Utility functions for dataset processing."""
+
+from datasets import Dataset, load_dataset
+
+
+def formatted_train(input: str, response: str) -> str:
+    """Format the input and response into the chat prompt format."""
+    return f"<|user|>\n{input}</s>\n<|assistant|>\n{response}</s>"
+
+
+def prepare_train_data(dataset: str) -> Dataset:
+    """Prepare the training data for the MTLLM model."""
+    dataset = load_dataset(dataset)
+    dataset_df = dataset.to_pandas()
+    dataset_df["text"] = dataset_df[["meaning_in", "meaning_out"]].apply(
+        lambda x: formatted_train(x["meaning_in"], x["meaning_out"]), axis=1
+    )
+    dataset = Dataset.from_pandas(dataset_df)
+    return dataset

--- a/support/mtllm_finetune/utils/model.py
+++ b/support/mtllm_finetune/utils/model.py
@@ -1,0 +1,21 @@
+"""Utility functions for model."""
+
+from transformers import AutoModelForCausalLM, AutoTokenizer, BitsAndBytesConfig
+
+
+def get_model_tokenizer(model_id: str) -> tuple:
+    """Get the model and tokenizer for the given model_id."""
+    tokenizer = AutoTokenizer.from_pretrained(model_id)
+    tokenizer.pad_token = tokenizer.eos_token
+    bnb_config = BitsAndBytesConfig(
+        load_in_4bit=True,
+        bnb_4bit_quant_type="nf4",
+        bnb_4bit_compute_dtype="float16",
+        bnb_4bit_use_double_quant=True,
+    )
+    model = AutoModelForCausalLM.from_pretrained(
+        model_id, quantization_config=bnb_config, device_map="auto"
+    )
+    model.config.use_cache = False
+    model.config.pretraining_tp = 1
+    return model, tokenizer


### PR DESCRIPTION
This PR Introduces tested training scripts for training TinyLlama 1.1B - v1.0 Model for MTLLM Model Training. Training Script should work with other models but not tested. Also the Synthetic Jac Code Generation Script for creating Example ByLLM Code inorder to run and generate Meaning In and Expected Meaning Out.