### PR TITLE
[DOCS] [FIX] [Update] code snippet syntax errors in genai documentation mkdocs file.

### DIFF
--- a/support/jac-lang.org/docs/learn/with_llm.md
+++ b/support/jac-lang.org/docs/learn/with_llm.md
@@ -103,7 +103,7 @@ In the jac program that you require to inference an LLM, please code as followin
     ```jac linenums="1"
     import:py from jaclang.core.llms, Huggingface;
 
-    glob llm = Ollama(
+    glob llm = Huggingface(
                 model_name = "mistralai/Mistral-7B-v0.3" # Will pull model if does not exists
                 );
     ```
@@ -117,12 +117,50 @@ The llm model is defined in these examples which can be intialized with specific
 This approach allows for the initialization of the desired model as a model code construct with a specific name (in this case, `llm`), facilitating its integration into code.
 
 **Example Usage**
+You can directly access some of our full code examples here for using the by_llm feature. We will break down the functional components later on.
+
+=== "Translator"
+    ```jac linenums="1"
+    --8<-- "examples/genai/translator.jac"
+    ```
+=== "Personality Finder"
+    ```jac linenums="1"
+    --8<-- "examples/genai/personality_finder.jac"
+    ```
+=== "Essay Reviewer"
+    ```jac linenums="1"
+    --8<-- "examples/genai/essay_review.jac"
+    ```
+=== "Expert Answer"
+    ```jac linenums="1"
+    --8<-- "examples/genai/expert_answer.jac"
+    ```
+=== "Grammar Checker"
+    ```jac linenums="1"
+    --8<-- "examples/genai/grammar_checker.jac"
+    ```
+=== "Joke Generator"
+    ```jac linenums="1"
+    --8<-- "examples/genai/joke_gen.jac"
+    ```
+=== "Odd Word Out"
+    ```jac linenums="1"
+    --8<-- "examples/genai/odd_word_out.jac"
+    ```
+=== "Text to Type"
+    ```jac linenums="1"
+    --8<-- "examples/genai/text_to_type.jac"
+    ```
+=== "Wikipedia"
+    ```jac linenums="1"
+    --8<-- "examples/genai/wikipedia.jac"
+    ```
 
 **1. Function Usage**
-```
+```jac linenums="1"
 can 'Summarize the Life of the Individual'
 summarize(name: 'Name of the Person': str, age: 'Age of the Person': int)
-    -> 'Summary': str by llm(temperature=0.7, reason=True);
+    -> 'Summary': str by llm(temperature=0.7, method='Reason');
 with entry {
     print(summarize('Albert Einstein', 89));
 }
@@ -130,17 +168,17 @@ with entry {
 In this example, the summarize function leverages GenAI Ability to provide a summary of an individual's life. The associated Semstring ('Name of the Person', 'Age of the Person') guides the function's behavior. The `by llm` feature allows customization of the interaction, with parameters like temperature and reason influencing the model's response.
 
 **2. Method Usage**
-```
+```jac linenums="1"
 obj 'Person'
 Person {
-    has name: 'Name' str,
-        dob: 'Date of Birth' str,
-        age: 'Age' int = None;
+    has name: 'Name': str,
+        dob: 'Date of Birth': str,
+        age: 'Age': int = None;
     can 'Calculate the Age of a Person'
     calculate (cur_year: 'Current Year': int) -> 'Calculated Age': int by llm();
 }
 with entry {
-    einstein 'Einstein Object': Person = Person(name="Einstein", dob="1879-03-14");
+    einstein: 'Einstein Object': Person = Person(name="Einstein", dob="1879-03-14");
     age = einstein.calculate(cur_year=2024);
     einstein.age = age;
     print(einstein.age);
@@ -151,15 +189,15 @@ In this example, the calculate method of the 'Person' object utilizes GenAI Abil
 **3.Object Creation**
 
 Simplify object creation with attributes automatically populated by LLM.
-```
+```jac linenums="1"
 obj 'Person'
 Person {
-    has name: 'Name' str,
-        dob: 'date of birth' str,
+    has name: 'Name': str,
+        dob: 'date of birth': str,
         accomplishments: 'Accomplishments': list[str];
 }
 with entry {
-    einstein: 'Einstein Object': Person = Person(name="Albert Einstein") by llm1();
+    einstein: 'Einstein Object': Person = Person(name="Albert Einstein" by llm());
     print(f"{einstein.name} was born on {einstein.dob}. His accomplishments include {einstein.accomplishments}.");
 }
 ```
@@ -172,8 +210,8 @@ Automatic Attribute Population: GenAI Ability streamlines object creation by aut
 
 When using `by <model>` in code, we have the ability to provide additional parameters for fine-tuning the interaction and to customize the interaction.
 
-```
-by <model>(temperature=0.7, top_k = 3, reason=true, incl_info=(xxx), context=[])
+```jac linenums="1"
+by <model>(temperature=0.7, top_k = 3, method='Reason', incl_info=(xxx), context=[])
 ```
 
 Here,
@@ -184,9 +222,9 @@ Here,
 
 - `model hyperparameters`: Key-value pairs specifying hyperparameters for the model during inference, e.g., temperature=0.7, top_k=3, top_p=0.51.
 
- - `reason`:A boolean indicating whether to include reasoning/explanation in the model's responses.
+ - `method`: A dictionary key for using different prompting style hints such as Reasoning and Chain-of-Through etc..
 
-- `context`: List of information to give external information to llm for our use cases
+- `context`: List of information to give external information to llm for our use cases.
 
 `by <model>(temperature=0.7, top_k = 3, top_p =0.51, incl_info=(xxx), context=[""],reason=true) ` <!--TODO : This line needs to be modified  with a working example code snippet later  -->
 
@@ -218,8 +256,8 @@ Utilizing Semstrings in Various Cases
 
 <h3 id="architype-declaration">Architype Declaration</h3>
 
-```
-obj "A collection of dad jokes with punchlines"
+```jac linenums="1"
+obj 'A collection of dad jokes with punchlines'
 JokeList {
     has jokes: list[tuple[str, str]];
 }
@@ -230,7 +268,7 @@ In this architype(Object) declaration, the semstring <span style="color:orange;"
 
 <h3 id="enum-declaration">Enum and Enum Items Declaration</h3>
 
-```
+```jac linenums="1"
 enum 'Personality of the Person'
 Personality {
    INTROVERT: 'Person who is shy and reticent',
@@ -242,7 +280,7 @@ In this enum declaration, the semstring <span style="color:orange;">'Personality
 
 <h3 id="global-variables-declaration">Global variables Declaration</h3>
 
-```
+```jac linenums="1"
 glob personality_examples: 'Personality Information of Famous People': dict[str, Personality|None] = {
     'Albert Einstein': Personality.INTROVERT,
     'Barack Obama': Personality.EXTROVERT
@@ -255,7 +293,7 @@ In this global variable declaration, the semstring <span style="color:orange;">'
 
  Semstrings play a pivotal role in method and ability declarations, offering a clear and concise description of their intended purpose—essentially defining the action each ability or method is designed to perform.
 
-```
+```jac linenums="1"
 can 'Translate English to French'
 translate(english_word: 'English Word': str) -> 'French Word' : str by llm();
 ```
@@ -266,21 +304,21 @@ In this instance, the semstring <span style="color:orange;">'Translate English t
 <h3 id="ability-method-parameter-declaration">Ability/Method Parameter Declaration</h3>
 
  Semstrings shine prominently in method signatures, serving as guides to define parameters with explicit meanings. By providing meaningful labels, developers ensure that LLM comprehends the purpose and expected inputs clearly. These semstrings also contribute to explaining the input with meaningful context.
-```
+```jac linenums="1"
 can 'Provide the Answer for the Given Question (A-F)'
-get_answer(question: 'Question' str, choices: 'Answer Choices': dict) -> 'Answer (A-F)' str by llm(reason=True);
+get_answer(question: 'Question' str, choices: 'Answer Choices': dict) -> 'Answer (A-F)' str by llm(method='Reason');
 ```
 In this instance, the semstrings for parameters (<span style="color:orange;">'Question'</span> and <span style="color:orange;">'Answer Choices'</span>) act as informative labels, offering a clear understanding of what each parameter represents. The labels provide context to LLM, guiding it to interpret and respond to the function's inputs appropriately.
 
 <h3 id="attributes-of-architypes">Attributes of Architypes</h3>
 
 Semstrings play a vital role in describing attributes within architypes, providing a succinct and clear explanation of the purpose and nature of each attribute. This practice makes it easier to convey the respective meanings to prompts.
-```
+```jac linenums="1"
 obj 'Singer'
 Singer {
-    has name: 'Name of the Singer' str,
-        age: 'Age' int,
-        top_songs: "His/Her's Top 2 Songs" list[str];
+    has name: 'Name of the Singer': str,
+        age: 'Age': int,
+        top_songs: "His/Her's Top 2 Songs": list[str];
 }
 ```
 In this architype example, the semstrings associated with attributes (<span style="color:orange;">'Name of the Singer'</span>, <span style="color:orange;">'Age,'</span> and <span style="color:orange;">"His/Her's Top 2 Songs"</span>) serve as concise descriptors. These semstrings effectively communicate the significance of each attribute, facilitating a more straightforward understanding of the architype's structure.
@@ -288,9 +326,9 @@ In this architype example, the semstrings associated with attributes (<span styl
 <h3 id="return-type-specification">Return Type Specification</h3>
 
 Utilizing Semstring in return type specifications provides a meaningful way to explain the expected outputs of a function.
-```
+```jac linenums="1"
 can 'Summarize the Accomplishments'
-summarize (a: 'Accomplishments': list[str]) -> 'Summary of the Accomplishments' : str by llm;
+summarize (a: 'Accomplishments': list[str]) -> 'Summary of the Accomplishments' : str by llm();
 ```
 In this example, the semstring <span style="color:orange;">'Summary of the Accomplishments' </span> precisely communicates the nature of the expected output. This clarity ensures that developers, as well as LLM, comprehend the type of information that will be returned by invoking the 'Summarize the Accomplishments' function.
-how ?
+<!-- how ? -->


### PR DESCRIPTION
# **[DOCS] [FIX] [Update] code snippet syntax errors in genai documentation mkdocs file.**

This PR reolves three issues, one being the syntax errors in code snippet examples in with_llm file of docs. The other is adding direct references to the working code examples for with_llm, which can be visualized through the genai docs. Also added code highlighter.