### PR TITLE
[FIX] Include fn name if semstring is not available in abilities

### DIFF
--- a/jaclang/compiler/passes/main/pyast_gen_pass.py
+++ b/jaclang/compiler/passes/main/pyast_gen_pass.py
@@ -1104,7 +1104,7 @@ class PyastGenPass(Pass):
             action = (
                 node.semstr.gen.py_ast[0]
                 if node.semstr
-                else self.sync(ast3.Constant(value=None))
+                else self.sync(ast3.Constant(value=node.name_ref.sym_name))
             )
             return [
                 self.sync(


### PR DESCRIPTION
Include fn name if semstring is not available in abilities