### PR TITLE
'Go to References' VSCE

### DIFF
--- a/jaclang/langserve/engine.py
+++ b/jaclang/langserve/engine.py
@@ -435,6 +435,24 @@ class JacLangServer(LanguageServer):
         else:
             return None
 
+    def get_references(
+        self, file_path: str, position: lspt.Position
+    ) -> list[lspt.Location]:
+        """Return references for a file."""
+        node_selected = find_deepest_symbol_node_at_pos(
+            self.modules[file_path].ir, position.line, position.character
+        )
+        if node_selected and node_selected.sym:
+            list_of_references: list[lspt.Location] = [
+                lspt.Location(
+                    uri=uris.from_fs_path(node.loc.mod_path),
+                    range=create_range(node.loc),
+                )
+                for node in node_selected.sym.uses
+            ]
+            return list_of_references
+        return []
+
     def get_semantic_tokens(self, file_path: str) -> lspt.SemanticTokens:
         """Return semantic tokens for a file."""
         if file_path not in self.modules:

--- a/jaclang/langserve/server.py
+++ b/jaclang/langserve/server.py
@@ -113,6 +113,12 @@ def definition(
     return ls.get_definition(params.text_document.uri, params.position)
 
 
+@server.feature(lspt.TEXT_DOCUMENT_REFERENCES)
+def references(ls: JacLangServer, params: lspt.ReferenceParams) -> list[lspt.Location]:
+    """Provide references."""
+    return ls.get_references(params.text_document.uri, params.position)
+
+
 @server.feature(
     lspt.TEXT_DOCUMENT_SEMANTIC_TOKENS_FULL,
     lspt.SemanticTokensLegend(


### PR DESCRIPTION
Implement get_references() method and references() feature to locate symbol usages across files.
![image](https://github.com/Jaseci-Labs/jaclang/assets/153247429/728c1cdd-bfeb-47a0-8a9c-29a845e34b16)
