### PR TITLE
Add --version flag to Jac CLI

### DIFF
--- a/jaclang/cli/cli.py
+++ b/jaclang/cli/cli.py
@@ -437,10 +437,17 @@ def start_cli() -> None:
     parser = cmd_registry.parser
     args = parser.parse_args()
     cmd_registry.args = args
+
+    if args.version:
+        version = importlib.metadata.version("jaclang")
+        print(f"Jac version {version}")
+        return
+
     command = cmd_registry.get(args.command)
     if command:
         args_dict = vars(args)
         args_dict.pop("command")
+        args_dict.pop("version", None)
         if command not in ["run"]:
             args_dict.pop("session")
         ret = command.call(**args_dict)

--- a/jaclang/cli/cmdreg.py
+++ b/jaclang/cli/cmdreg.py
@@ -40,6 +40,9 @@ class CommandRegistry:
         self.parser.add_argument(
             "--session", help="Session file path", nargs="?", default=""
         )
+        self.parser.add_argument(
+            "-V", "--version", action="store_true", help="Show the Jac version"
+        )
         self.sub_parsers = self.parser.add_subparsers(title="commands", dest="command")
         self.args = argparse.Namespace()
 


### PR DESCRIPTION
### Description

This PR introduces a **--version (-V)** flag to the Jac CLI, allowing users to quickly check the installed version of Jac. 


![image](https://github.com/user-attachments/assets/d3aea855-b98e-4c57-a2b3-4afbc5381f96)
