### PR TITLE
Fix Formatter Alignment Issue with Comments and has Variables

### DIFF
--- a/jaclang/compiler/passes/tool/jac_formatter_pass.py
+++ b/jaclang/compiler/passes/tool/jac_formatter_pass.py
@@ -281,6 +281,7 @@ class JacFormatPass(Pass):
                             self.emit(node, stmt.gen.jac)
                             if not stmt.gen.jac.endswith("postinit;"):
                                 self.indent_level -= 1
+                                self.emit_ln(stmt, "")
                                 self.emit_ln(node, "")
                                 self.indent_level += 1
                 elif stmt.gen.jac == ",":
@@ -747,7 +748,7 @@ class JacFormatPass(Pass):
                             self.indent_level += indent_val
                             indented = True
                     else:
-                        self.emit(node, f"{j.gen.jac.strip()}")
+                        self.emit(node, j.gen.jac.lstrip())
                 if indented:
                     self.indent_level -= indent_val
             else:

--- a/jaclang/compiler/passes/tool/tests/fixtures/general_format_checks/comment_alignment.jac
+++ b/jaclang/compiler/passes/tool/tests/fixtures/general_format_checks/comment_alignment.jac
@@ -1,5 +1,3 @@
-
-
 obj inner_red {
     has color22: string = 'red',
         # self
@@ -8,6 +6,6 @@ obj inner_red {
         # self
         doublepoint33: int = 2,
         # Comments explaining each attribute
-    # color22: represents the color, set to 'red'
+        # color22: represents the color, set to 'red'
         point22: int = 20;
 }

--- a/jaclang/compiler/passes/tool/tests/fixtures/general_format_checks/comment_alignment.jac
+++ b/jaclang/compiler/passes/tool/tests/fixtures/general_format_checks/comment_alignment.jac
@@ -1,0 +1,13 @@
+
+
+obj inner_red {
+    has color22: string = 'red',
+        # self
+        doublepoint11: int = 2,
+        doublepoint22: float = 2.0,
+        # self
+        doublepoint33: int = 2,
+        # Comments explaining each attribute
+    # color22: represents the color, set to 'red'
+        point22: int = 20;
+}


### PR DESCRIPTION
This PR addresses an issue with the formatter that incorrectly aligns has variables and comments in the code. 
The test file `comment_alignment.jac` has been added to `general_format_checks` to ensure proper alignment of variables and comments. 


**Original code   vs   Formatted code**
![image](https://github.com/user-attachments/assets/f8a30059-f12b-43fb-8229-d6dba2effd10)
