### PR TITLE
Dumping traceback of runtime errors impl

### DIFF
--- a/jaclang/runtimelib/importer.py
+++ b/jaclang/runtimelib/importer.py
@@ -15,6 +15,7 @@ from jaclang.compiler.compile import compile_jac
 from jaclang.compiler.constant import Constants as Con
 from jaclang.runtimelib.machine import JacMachine
 from jaclang.runtimelib.utils import sys_path_context
+from jaclang.utils.helpers import dump_traceback
 from jaclang.utils.log import logging
 
 logger = logging.getLogger(__name__)
@@ -169,9 +170,10 @@ class ImportReturn:
             exec(codeobj, new_module.__dict__)
             return getattr(new_module, name, new_module)
         except ImportError as e:
-            logger.error(
-                f"Failed to load {name} from {jac_file_path} in {module.__name__}: {str(e)}"
-            )
+            logger.error(dump_traceback(e))
+            # logger.error(
+            #     f"Failed to load {name} from {jac_file_path} in {module.__name__}: {str(e)}"
+            # )
             return None
 
 
@@ -403,7 +405,7 @@ class JacImporter(Importer):
                     try:
                         exec(codeobj, module.__dict__)
                     except Exception as e:
-                        logger.error(f"Error while importing {spec.full_target}: {e}")
+                        logger.error(dump_traceback(e))
                         raise e
         import_return = ImportReturn(module, unique_loaded_items, self)
         if spec.items:

--- a/jaclang/tests/fixtures/err_runtime.jac
+++ b/jaclang/tests/fixtures/err_runtime.jac
@@ -1,0 +1,15 @@
+
+can bar(some_list:list) {
+    invalid_index = 4;
+    print(some_list[invalid_index]);  # This should fail.
+}
+
+
+can foo() {
+    bar([0, 1, 2, 3]);
+}
+
+
+with entry {
+    foo();
+}

--- a/jaclang/tests/test_cli.py
+++ b/jaclang/tests/test_cli.py
@@ -49,6 +49,33 @@ class JacCliTests(TestCase):
         # print(stdout_value)
         self.assertIn("Error", stdout_value)
 
+    def test_jac_cli_alert_based_runtime_err(self) -> None:
+        """Basic test for pass."""
+        captured_output = io.StringIO()
+        sys.stdout = captured_output
+        sys.stderr = captured_output
+
+        try:
+            cli.run(self.fixture_abs_path("err_runtime.jac"))
+        except Exception as e:
+            print(f"Error: {e}")
+
+        sys.stdout = sys.__stdout__
+        sys.stderr = sys.__stderr__
+
+        expected_stdout_values = (
+            "Error: list index out of range",
+            "    print(some_list[invalid_index]);",
+            "          ^^^^^^^^^^^^^^^^^^^^^^^^",
+            "  at bar() ",
+            "  at foo() ",
+            "  at <module> ",
+        )
+
+        logger_capture = "\n".join([rec.message for rec in self.caplog.records])
+        for exp in expected_stdout_values:
+            self.assertIn(exp, logger_capture)
+
     def test_jac_impl_err(self) -> None:
         """Basic test for pass."""
         if "jaclang.tests.fixtures.err" in sys.modules:

--- a/jaclang/utils/test.py
+++ b/jaclang/utils/test.py
@@ -5,14 +5,23 @@ import os
 from typing import Callable, Optional
 from unittest import TestCase as _TestCase
 
+from _pytest.logging import LogCaptureFixture
 
 import jaclang
 from jaclang.compiler.passes import Pass
 from jaclang.utils.helpers import get_ast_nodes_as_snake_case as ast_snakes
 
+import pytest
+
 
 class TestCase(_TestCase):
     """Base test case for Jaseci."""
+
+    # Reference: https://stackoverflow.com/a/50375022
+    @pytest.fixture(autouse=True)
+    def inject_fixtures(self, caplog: LogCaptureFixture) -> None:
+        """Store the logger capture records within the tests."""
+        self.caplog = caplog
 
     def setUp(self) -> None:
         """Set up test case."""


### PR DESCRIPTION
## **Description**

This will pretty dump the traceback of a runtime error. with anchors `^` indicating the exact location of the exception along with the stack frames (function name, file, line).
 
![Screenshot 2024-07-10 105455](https://github.com/Jaseci-Labs/jaclang/assets/41085900/5192266c-0d51-40bd-b0fc-b19419192b7b)
