### PR TITLE
[CHORE] Adding Semstrings of abilities to SemRegistry

### DIFF
--- a/jaclang/compiler/passes/main/registry_pass.py
+++ b/jaclang/compiler/passes/main/registry_pass.py
@@ -95,11 +95,14 @@ class RegistryPass(Pass):
         if len(self.modules_visited) and self.modules_visited[-1].registry:
             self.modules_visited[-1].registry.add(scope, seminfo)
 
-        if isinstance(node.signature, ast.EventSignature):
-            if len(self.modules_visited) and self.modules_visited[-1].registry:
-                self.modules_visited[-1].registry.add(
-                    get_sem_scope(node), SemInfo("No Input Params", "")
-                )
+        if (
+            isinstance(node.signature, ast.EventSignature)
+            and len(self.modules_visited)
+            and self.modules_visited[-1].registry
+        ):
+            self.modules_visited[-1].registry.add(
+                get_sem_scope(node), SemInfo("No Input Params", "")
+            )
 
     def exit_param_var(self, node: ast.ParamVar) -> None:
         """Save param information"""

--- a/jaclang/compiler/passes/main/registry_pass.py
+++ b/jaclang/compiler/passes/main/registry_pass.py
@@ -105,7 +105,7 @@ class RegistryPass(Pass):
             )
 
     def exit_param_var(self, node: ast.ParamVar) -> None:
-        """Save param information"""
+        """Save param information."""
         scope = get_sem_scope(node)
         extracted_type = (
             "".join(self.extract_type(node.type_tag.tag)) if node.type_tag else None

--- a/jaclang/compiler/passes/main/registry_pass.py
+++ b/jaclang/compiler/passes/main/registry_pass.py
@@ -38,6 +38,7 @@ class RegistryPass(Pass):
                 os.path.join(module_dir, f"{module_name}.registry.pkl"), "wb"
             ) as f:
                 pickle.dump(node.registry, f)
+                print(node.registry.pp())
         except Exception as e:
             self.warning(f"Can't save registry for {module_name}: {e}")
         self.modules_visited.pop()
@@ -86,7 +87,7 @@ class RegistryPass(Pass):
 
     def exit_ability(self, node: ast.Ability) -> None:
         """Save ability information."""
-        scope = get_sem_scope(node.owner_method)    # type: ignore[arg-type]
+        scope = get_sem_scope(node.parent)  # type: ignore[arg-type]
         seminfo = SemInfo(
             node.name_ref.sym_name,
             "Ability",

--- a/jaclang/compiler/passes/main/registry_pass.py
+++ b/jaclang/compiler/passes/main/registry_pass.py
@@ -86,7 +86,7 @@ class RegistryPass(Pass):
 
     def exit_ability(self, node: ast.Ability) -> None:
         """Save ability information."""
-        scope_node = node.parent
+        scope_node : ast.AstNode = node.parent
         scope = get_sem_scope(scope_node)
         seminfo = SemInfo(
             node.name_ref.sym_name,

--- a/jaclang/compiler/passes/main/registry_pass.py
+++ b/jaclang/compiler/passes/main/registry_pass.py
@@ -38,6 +38,7 @@ class RegistryPass(Pass):
                 os.path.join(module_dir, f"{module_name}.registry.pkl"), "wb"
             ) as f:
                 pickle.dump(node.registry, f)
+                print(node.registry.pp())
         except Exception as e:
             self.warning(f"Can't save registry for {module_name}: {e}")
         self.modules_visited.pop()
@@ -86,8 +87,8 @@ class RegistryPass(Pass):
 
     def exit_ability(self, node: ast.Ability) -> None:
         """Save ability information."""
-        scope_node : ast.AstNode = node.parent
-        scope = get_sem_scope(scope_node)
+        # scope_node = node.parent
+        scope = get_sem_scope(node.owner_method)
         seminfo = SemInfo(
             node.name_ref.sym_name,
             "Ability",

--- a/jaclang/compiler/passes/main/registry_pass.py
+++ b/jaclang/compiler/passes/main/registry_pass.py
@@ -38,7 +38,6 @@ class RegistryPass(Pass):
                 os.path.join(module_dir, f"{module_name}.registry.pkl"), "wb"
             ) as f:
                 pickle.dump(node.registry, f)
-                print(node.registry.pp())
         except Exception as e:
             self.warning(f"Can't save registry for {module_name}: {e}")
         self.modules_visited.pop()

--- a/jaclang/compiler/passes/main/registry_pass.py
+++ b/jaclang/compiler/passes/main/registry_pass.py
@@ -38,6 +38,8 @@ class RegistryPass(Pass):
                 os.path.join(module_dir, f"{module_name}.registry.pkl"), "wb"
             ) as f:
                 pickle.dump(node.registry, f)
+                print(node.registry.pp())
+                # print(node.registry.registry[list(node.registry.registry.keys())[2]])
         except Exception as e:
             self.warning(f"Can't save registry for {module_name}: {e}")
         self.modules_visited.pop()
@@ -86,10 +88,30 @@ class RegistryPass(Pass):
 
     def exit_ability(self, node: ast.Ability) -> None:
         """Save ability information."""
-        scope = get_sem_scope(node)
+        scope = get_sem_scope(node.parent)
         seminfo = SemInfo(
             node.name_ref.sym_name,
-            None,
+            "Ability",
+            node.semstr.lit_value if node.semstr else "",
+        )
+        if len(self.modules_visited) and self.modules_visited[-1].registry:
+            self.modules_visited[-1].registry.add(scope, seminfo)
+
+        if isinstance(node.signature, ast.EventSignature):
+            if len(self.modules_visited) and self.modules_visited[-1].registry:
+                self.modules_visited[-1].registry.add(
+                    get_sem_scope(node), SemInfo("No Input Params", "")
+                )
+
+    def exit_param_var(self, node: ast.ParamVar) -> None:
+        """Save param information"""
+        scope = get_sem_scope(node)
+        extracted_type = (
+            "".join(self.extract_type(node.type_tag.tag)) if node.type_tag else None
+        )
+        seminfo = SemInfo(
+            node.name.value,
+            extracted_type,
             node.semstr.lit_value if node.semstr else "",
         )
         if len(self.modules_visited) and self.modules_visited[-1].registry:

--- a/jaclang/compiler/passes/main/registry_pass.py
+++ b/jaclang/compiler/passes/main/registry_pass.py
@@ -86,7 +86,8 @@ class RegistryPass(Pass):
 
     def exit_ability(self, node: ast.Ability) -> None:
         """Save ability information."""
-        scope = get_sem_scope(node.parent)
+        scope_node = node.parent
+        scope = get_sem_scope(scope_node)
         seminfo = SemInfo(
             node.name_ref.sym_name,
             "Ability",

--- a/jaclang/compiler/passes/main/registry_pass.py
+++ b/jaclang/compiler/passes/main/registry_pass.py
@@ -38,7 +38,6 @@ class RegistryPass(Pass):
                 os.path.join(module_dir, f"{module_name}.registry.pkl"), "wb"
             ) as f:
                 pickle.dump(node.registry, f)
-                print(node.registry.pp())
         except Exception as e:
             self.warning(f"Can't save registry for {module_name}: {e}")
         self.modules_visited.pop()
@@ -87,8 +86,7 @@ class RegistryPass(Pass):
 
     def exit_ability(self, node: ast.Ability) -> None:
         """Save ability information."""
-        # scope_node = node.parent
-        scope = get_sem_scope(node.owner_method)
+        scope = get_sem_scope(node.owner_method)    # type: ignore[arg-type]
         seminfo = SemInfo(
             node.name_ref.sym_name,
             "Ability",

--- a/jaclang/compiler/passes/main/registry_pass.py
+++ b/jaclang/compiler/passes/main/registry_pass.py
@@ -84,6 +84,17 @@ class RegistryPass(Pass):
         if len(self.modules_visited) and self.modules_visited[-1].registry:
             self.modules_visited[-1].registry.add(scope, seminfo)
 
+    def exit_ability(self, node: ast.Ability) -> None:
+        """Save ability information."""
+        scope = get_sem_scope(node)
+        seminfo = SemInfo(
+            node.name_ref.sym_name,
+            None,
+            node.semstr.lit_value if node.semstr else "",
+        )
+        if len(self.modules_visited) and self.modules_visited[-1].registry:
+            self.modules_visited[-1].registry.add(scope, seminfo)
+
     def exit_assignment(self, node: ast.Assignment) -> None:
         """Save assignment information."""
         if node.aug_op:

--- a/jaclang/compiler/passes/main/registry_pass.py
+++ b/jaclang/compiler/passes/main/registry_pass.py
@@ -38,8 +38,6 @@ class RegistryPass(Pass):
                 os.path.join(module_dir, f"{module_name}.registry.pkl"), "wb"
             ) as f:
                 pickle.dump(node.registry, f)
-                print(node.registry.pp())
-                # print(node.registry.registry[list(node.registry.registry.keys())[2]])
         except Exception as e:
             self.warning(f"Can't save registry for {module_name}: {e}")
         self.modules_visited.pop()

--- a/jaclang/compiler/semtable.py
+++ b/jaclang/compiler/semtable.py
@@ -38,7 +38,8 @@ class SemScope:
         """Return the string representation of the class."""
         if self.parent:
             return f"{self.parent}.{self.scope}({self.type})"
-        return f"{self.scope}({self.type})"
+        else:
+            return f"{self.scope}({self.type})"
 
     def __repr__(self) -> str:
         """Return the string representation of the class."""
@@ -57,7 +58,7 @@ class SemScope:
 
     @property
     def as_type_str(self) -> Optional[str]:
-        """Return the type string representation of the SemsScope."""
+        """Return the type string representation of the SemScope."""
         if self.type not in ["class", "node", "obj"]:
             return None
         type_str = self.scope

--- a/jaclang/runtimelib/utils.py
+++ b/jaclang/runtimelib/utils.py
@@ -127,11 +127,11 @@ def get_sem_scope(node: ast.AstNode) -> SemScope:
             if isinstance(node, ast.Enum)
             else ("Ability" if isinstance(node, ast.Ability) else node.arch_type.value)
         )
-        if node.parent or isinstance(node, ast.Ability):
+        if node.parent:
             return SemScope(a, node_type, get_sem_scope(node.parent))
     else:
         if node.parent:
-            return get_sem_scope(node.parent)
+            return get_sem_scope(node.parent) if not isinstance(node, ast.Ability) else get_sem_scope(node.owner_method)
     return SemScope("", "", None)
 
 

--- a/jaclang/runtimelib/utils.py
+++ b/jaclang/runtimelib/utils.py
@@ -108,7 +108,7 @@ def traverse_graph(
                     dfs(other_nd, cur_depth + 1)
 
 
-def get_sem_scope(node: ast.AstNode | None) -> SemScope:
+def get_sem_scope(node: ast.AstNode) -> SemScope:
     """Get scope of the node."""
     a = (
         node.name

--- a/jaclang/runtimelib/utils.py
+++ b/jaclang/runtimelib/utils.py
@@ -113,17 +113,21 @@ def get_sem_scope(node: ast.AstNode) -> SemScope:
     a = (
         node.name
         if isinstance(node, ast.Module)
-        else node.name.value if isinstance(node, (ast.Enum, ast.Architype)) else ""
+        else (
+            node.name.value
+            if isinstance(node, (ast.Enum, ast.Architype))
+            else node.name_ref.sym_name if isinstance(node, ast.Ability) else ""
+        )
     )
     if isinstance(node, ast.Module):
         return SemScope(a, "Module", None)
-    elif isinstance(node, (ast.Enum, ast.Architype)):
+    elif isinstance(node, (ast.Enum, ast.Architype, ast.Ability)):
         node_type = (
             node.__class__.__name__
             if isinstance(node, ast.Enum)
-            else node.arch_type.value
+            else ("Ability" if isinstance(node, ast.Ability) else node.arch_type.value)
         )
-        if node.parent:
+        if node.parent or isinstance(node, ast.Ability):
             return SemScope(a, node_type, get_sem_scope(node.parent))
     else:
         if node.parent:

--- a/jaclang/runtimelib/utils.py
+++ b/jaclang/runtimelib/utils.py
@@ -108,7 +108,7 @@ def traverse_graph(
                     dfs(other_nd, cur_depth + 1)
 
 
-def get_sem_scope(node: ast.AstNode) -> SemScope:
+def get_sem_scope(node: ast.AstNode | None) -> SemScope:
     """Get scope of the node."""
     a = (
         node.name

--- a/jaclang/runtimelib/utils.py
+++ b/jaclang/runtimelib/utils.py
@@ -128,10 +128,14 @@ def get_sem_scope(node: ast.AstNode) -> SemScope:
             else ("Ability" if isinstance(node, ast.Ability) else node.arch_type.value)
         )
         if node.parent:
-            return SemScope(a, node_type, get_sem_scope(node.parent))
+            return SemScope(
+                a,
+                node_type,
+                get_sem_scope(node.parent),
+            )
     else:
         if node.parent:
-            return get_sem_scope(node.parent) if not isinstance(node, ast.Ability) else get_sem_scope(node.owner_method)
+            return get_sem_scope(node.parent)
     return SemScope("", "", None)
 
 

--- a/jaclang/tests/test_language.py
+++ b/jaclang/tests/test_language.py
@@ -479,9 +479,9 @@ class JacLanguageTests(TestCase):
         ) as f:
             registry = pickle.load(f)
 
-        self.assertEqual(len(registry.registry), 3)
-        self.assertEqual(len(list(registry.registry.items())[0][1]), 10)
-        self.assertEqual(list(registry.registry.items())[1][0].scope, "Person")
+        self.assertEqual(len(registry.registry), 7)
+        self.assertEqual(len(list(registry.registry.items())[0][1]), 2)
+        self.assertEqual(list(registry.registry.items())[3][0].scope, "Person")
 
     def test_enum_inside_arch(self) -> None:
         """Test Enum as member stmt."""


### PR DESCRIPTION
## **Description**

- Added ```exit_ability``` method for RegistryPass
- Added ```exit_param_var``` method for RegistryPass
- Minor Changes in utilis.py and semtable
- Mypy ignored in exit_ability for node.parent where the node is an ability.

## **New Sem Registry PP**
```
guess_game5(Module).GuessGame(walker)
  correct_number int 
  start_game Ability Yolo
  process_guess Ability 
guess_game5(Module).GuessGame(walker).start_game(Ability)
  No Input Params  
guess_game5(Module).GuessGame(walker).process_guess(Ability)
  guess int 
guess_game5(Module)
  GuessGame walker Malo
  turn node 
  guess None 
  end `_Jac.get_root()|turn 
  i None 
  guess int 
guess_game5(Module).turn(node)
  check Ability 
guess_game5(Module).turn(node).check(Ability)
  No Input Params
```