### PR TITLE
Enhance Jaclang Class Method Handling: Disable "self"  Auto-Fill for Regular Classes 

### DIFF
--- a/jaclang/compiler/absyntree.py
+++ b/jaclang/compiler/absyntree.py
@@ -1530,7 +1530,7 @@ class FuncSignature(AstSemStrNode):
         )
 
     @property
-    def is_class_method(self) -> bool:
+    def is_in_py_class(self) -> bool:
         """Check if the ability belongs to a class."""
         is_archi = self.find_parent_of_type(Architype)
         is_class = is_archi is not None and is_archi.arch_type.name == Tok.KW_CLASS

--- a/jaclang/compiler/absyntree.py
+++ b/jaclang/compiler/absyntree.py
@@ -1529,6 +1529,23 @@ class FuncSignature(AstSemStrNode):
             and self.parent.decl_link.is_static
         )
 
+    @property
+    def is_class_method(self) -> bool:
+        """Check if the ability belongs to a class."""
+        is_archi = self.find_parent_of_type(Architype)
+        is_class = is_archi is not None and is_archi.arch_type.name == Tok.KW_CLASS
+
+        return (
+            isinstance(self.parent, Ability)
+            and self.parent.is_method is not None
+            and is_class
+        ) or (
+            isinstance(self.parent, AbilityDef)
+            and isinstance(self.parent.decl_link, Ability)
+            and self.parent.decl_link.is_method
+            and is_class
+        )
+
 
 class EventSignature(AstSemStrNode):
     """EventSignature node type for Jac Ast."""

--- a/jaclang/compiler/passes/main/pyast_gen_pass.py
+++ b/jaclang/compiler/passes/main/pyast_gen_pass.py
@@ -1595,7 +1595,7 @@ class PyastGenPass(Pass):
         """
         params = (
             [self.sync(ast3.arg(arg="self", annotation=None))]
-            if node.is_method and not node.is_static and not node.is_class_method
+            if node.is_method and not node.is_static and not node.is_in_py_class
             else []
         )
         vararg = None

--- a/jaclang/compiler/passes/main/pyast_gen_pass.py
+++ b/jaclang/compiler/passes/main/pyast_gen_pass.py
@@ -1595,7 +1595,7 @@ class PyastGenPass(Pass):
         """
         params = (
             [self.sync(ast3.arg(arg="self", annotation=None))]
-            if node.is_method and not node.is_static
+            if node.is_method and not node.is_static and not node.is_class_method
             else []
         )
         vararg = None

--- a/jaclang/tests/fixtures/cls_method.jac
+++ b/jaclang/tests/fixtures/cls_method.jac
@@ -1,0 +1,41 @@
+"""Test file for class method."""
+
+class MyClass {
+    can simple_method() -> str {
+        return "Hello, World1!";
+    }
+
+    @classmethod
+    can my_method(cls: any) -> str {
+        x = cls.__name__;
+        print(x);
+        return "Hello, World2!";
+    }
+}
+
+with entry {
+    a = MyClass.simple_method();
+    b = MyClass.my_method();
+    print(a, b);
+}
+
+class MyClass2 {
+    can Ability_1(self: any) -> str;
+    @classmethod
+    can Ability_2(cls: any) -> str;
+}
+
+:obj:MyClass2:can:Ability_1
+(self: any) {
+    return "Hello, World!";
+}
+
+:obj:MyClass2:can:Ability_2 {
+    return "Hello, World22!";
+}
+
+with entry {
+    a = MyClass2().Ability_1();
+    b = MyClass2.Ability_2();
+    print(a, b);
+}

--- a/jaclang/tests/fixtures/cls_method.jac
+++ b/jaclang/tests/fixtures/cls_method.jac
@@ -6,7 +6,7 @@ class MyClass {
     }
 
     @classmethod
-    can my_method(cls: any) -> str {
+    can my_method(cls: Type[MyClass]) -> str {
         x = cls.__name__;
         print(x);
         return "Hello, World2!";
@@ -20,13 +20,13 @@ with entry {
 }
 
 class MyClass2 {
-    can Ability_1(self: any) -> str;
+    can Ability_1(self: MyClass2) -> str;
     @classmethod
-    can Ability_2(cls: any) -> str;
+    can Ability_2(cls: Type[MyClass2]) -> str;
 }
 
 :obj:MyClass2:can:Ability_1
-(self: any) {
+(self: MyClass2) -> str {
     return "Hello, World!";
 }
 

--- a/jaclang/tests/fixtures/simple_archs.jac
+++ b/jaclang/tests/fixtures/simple_archs.jac
@@ -15,7 +15,7 @@ class SimpleClass {
         var2: int,
         var3: int = 0;
 
-    can init(self:any) {
+    can init(self: SimpleClass) {
         print(self.var3);
     }
 }

--- a/jaclang/tests/fixtures/simple_archs.jac
+++ b/jaclang/tests/fixtures/simple_archs.jac
@@ -15,7 +15,7 @@ class SimpleClass {
         var2: int,
         var3: int = 0;
 
-    can init {
+    can init(self:any) {
         print(self.var3);
     }
 }

--- a/jaclang/tests/test_language.py
+++ b/jaclang/tests/test_language.py
@@ -903,3 +903,14 @@ class JacLanguageTests(TestCase):
         stdout_value = captured_output.getvalue()
         self.assertEqual(stdout_value.count("Hello World!"), 1)
         self.assertIn("im still here", stdout_value)
+
+    def test_cls_method(self) -> None:
+        """Test class method output."""
+        captured_output = io.StringIO()
+        sys.stdout = captured_output
+        jac_import("cls_method", base_path=self.fixture_abs_path("./"))
+        sys.stdout = sys.__stdout__
+        stdout_value = captured_output.getvalue().split("\n")
+        self.assertEqual("MyClass", stdout_value[0])
+        self.assertEqual("Hello, World1! Hello, World2!", stdout_value[1])
+        self.assertEqual("Hello, World! Hello, World22!", stdout_value[2])


### PR DESCRIPTION
This pull request introduces enhancements to Jaclang's handling of class methods. Key changes include:

1. **Self Parameter Handling**:
   - Auto-fill of the `self` parameter is now disabled for regular classes.
   - Users must explicitly mention the `self` parameter in method signatures where needed.
   

![image](https://github.com/user-attachments/assets/77705d83-74b2-42a6-9501-8a8c90ff5ed5)


2. **Continued Support for Special Types**:
   - The `self` auto-fill feature remains active for **Architypes**`(obj,node,edge)`

3. **Updated Example and Test Cases**:    [jaclang/tests/fixtures/cls_method.jac ](https://github.com/Jaseci-Labs/jaclang/blob/cls_method_support/jaclang/tests/fixtures/cls_method.jac)
   - Updated examples demonstrate the new behavior for regular classes and methods, showing how to properly define and use `self` and `cls` parameters.
   - Test cases are included to verify the correctness of these changes.   

These modifications aim to provide clearer and more flexible handling of method parameters, aligning with traditional class behavior while maintaining specific features for our Architypes.

![image](https://github.com/user-attachments/assets/9ca6704a-2cdb-4fbb-b829-d2a73c8c68a0)
