### PR TITLE
Fix: Decorator Alignment in Formatter

### DIFF
--- a/jaclang/compiler/passes/tool/jac_formatter_pass.py
+++ b/jaclang/compiler/passes/tool/jac_formatter_pass.py
@@ -289,6 +289,8 @@ class JacFormatPass(Pass):
                     self.emit(node, f"{stmt.value} ")
                 elif stmt.value == "=":
                     self.emit(node, f" {stmt.value} ")
+                elif prev_token and prev_token.gen.jac.strip() == "@":
+                    self.emit_ln(node, stmt.value)
                 else:
                     self.emit(node, f"{stmt.gen.jac}")
                 prev_token = stmt

--- a/jaclang/compiler/passes/tool/tests/fixtures/general_format_checks/decorator_stack.jac
+++ b/jaclang/compiler/passes/tool/tests/fixtures/general_format_checks/decorator_stack.jac
@@ -1,0 +1,37 @@
+can star(func: Any) {
+    can inner(x: Any) {
+        print(("*" * 30));
+        func(x);
+        print(("*" * 30));
+    }
+    return inner;
+}
+
+can percent(func: Any) {
+    can inner(y: Any) {
+        print(("%" * 30));
+        func(y);
+        print(("%" * 30));
+    }
+    return inner;
+}
+
+can percent2(func: Any) {
+    can inner(y: Any) {
+        print(("-" * 30));
+        func(y);
+        print(("+" * 30));
+    }
+    return inner;
+}
+
+@star
+@percent
+@percent2
+can printer(msg: Any) {
+    print(msg);
+}
+
+with entry {
+    printer("Hello");
+}


### PR DESCRIPTION
Fixed issue where multiple decorators were placed on a single line instead of stacking.

![image](https://github.com/user-attachments/assets/0c89b932-7a87-4504-83d0-8456da60ad26)
