### PR TITLE
Enhance go_to_definition using abs_path

### DIFF
--- a/jaclang/compiler/absyntree.py
+++ b/jaclang/compiler/absyntree.py
@@ -1055,6 +1055,18 @@ class ModuleItem(AstSymbolNode):
         self.abs_path: Optional[str] = None
 
     @property
+    def loc_range(self) -> tuple[int, int, int, int]:
+        """Get location range."""
+        if not self.from_mod_path.sub_module:
+            raise ValueError("Module items should have module path. Not Possible.")
+        if not self.from_mod_path.sub_module.sym_tab.lookup(self.sym_name):
+            raise ValueError(
+                "Module items should have a symbol table entry. Not Possible."
+            )
+        loc = self.from_mod_path.sub_module.sym_tab.lookup(self.sym_name).decl.loc
+        return loc.first_line, loc.col_start, loc.col_end, loc.col_end
+
+    @property
     def from_parent(self) -> Import:
         """Get import parent."""
         if (

--- a/jaclang/compiler/absyntree.py
+++ b/jaclang/compiler/absyntree.py
@@ -1055,19 +1055,6 @@ class ModuleItem(AstSymbolNode):
         self.abs_path: Optional[str] = None
 
     @property
-    def loc_range(self) -> tuple[int, int, int, int]:
-        """Get location range."""
-        if not self.from_mod_path.sub_module:
-            raise ValueError("Module items should have module path. Not Possible.")
-        lookup = self.from_mod_path.sub_module.sym_tab.lookup(self.sym_name)
-        if not lookup:
-            raise ValueError(
-                "Module items should have a symbol table entry. Not Possible."
-            )
-        loc = lookup.decl.loc
-        return loc.first_line, loc.col_start, loc.col_end, loc.col_end
-
-    @property
     def from_parent(self) -> Import:
         """Get import parent."""
         if (

--- a/jaclang/compiler/absyntree.py
+++ b/jaclang/compiler/absyntree.py
@@ -1059,11 +1059,12 @@ class ModuleItem(AstSymbolNode):
         """Get location range."""
         if not self.from_mod_path.sub_module:
             raise ValueError("Module items should have module path. Not Possible.")
-        if not self.from_mod_path.sub_module.sym_tab.lookup(self.sym_name):
+        lookup = self.from_mod_path.sub_module.sym_tab.lookup(self.sym_name)
+        if not lookup:
             raise ValueError(
                 "Module items should have a symbol table entry. Not Possible."
             )
-        loc = self.from_mod_path.sub_module.sym_tab.lookup(self.sym_name).decl.loc
+        loc = lookup.decl.loc
         return loc.first_line, loc.col_start, loc.col_end, loc.col_end
 
     @property

--- a/jaclang/langserve/engine.py
+++ b/jaclang/langserve/engine.py
@@ -335,7 +335,6 @@ class JacLangServer(LanguageServer):
                 and isinstance(node_selected.parent, ast.ModulePath)
             ):
                 spec = node_selected.parent.abs_path
-                self.log_py(f"spec: {spec}")
                 if spec:
                     spec = spec[5:] if spec.startswith("File:") else spec
                     return lspt.Location(

--- a/jaclang/langserve/tests/fixtures/import_include_statements.jac
+++ b/jaclang/langserve/tests/fixtures/import_include_statements.jac
@@ -1,6 +1,6 @@
 import:py os;
-import:py from math, sqrt as square_root;
+import:py from math{ sqrt as square_root}
 import:py datetime as dt;
-import:jac from base_module_structure, add as add_numbers , subtract,x,Colorenum as clr;
+import:jac from base_module_structure{ add as add_numbers , subtract,x,Colorenum as clr}
 import:jac base_module_structure as base_module_structure;
-import:py from py_import,add1 as ss, sub1 as subtract1,apple,Orange1;
+import:py from py_import{add1 as ss, sub1 as subtract1,apple,Orange1}

--- a/jaclang/langserve/tests/test_server.py
+++ b/jaclang/langserve/tests/test_server.py
@@ -187,11 +187,15 @@ class TestJacLangServer(TestCase):
         )
         lsp.deep_check(import_file)
         positions = [
-            (2, 24, "datetime.py:0:0-0:0"),
+            (0, 12, "tdlib/os/__init__.pyi:0:0-0:0"),
+            (1, 18, "stdlib/math.pyi:0:0-0:0"),
+            (2, 24, "datetime.pyi:0:0-0:0"),
             (3, 17, "base_module_structure.jac:0:0-0:0"),
-            (3, 87, "base_module_structure.jac:23:0-23:5"),
-            (5, 65, "py_import.py:12:0-20:5"),
-            (5, 35, "py_import.py:3:0-4:5"),
+            (3, 87, "base_module_structure.jac:23:5-23:14"),
+            (5, 65, "py_import.py:0:0-0:0"),
+            (5, 35, "py_import.py:0:0-0:0"),
+            # (5, 65, "py_import.py:12:0-20:5"),  # TODO : Should work after 'from' import files are raised
+            # (5, 35, "py_import.py:3:0-4:5"),
         ]
 
         for line, char, expected in positions:

--- a/jaclang/langserve/utils.py
+++ b/jaclang/langserve/utils.py
@@ -206,6 +206,17 @@ def create_range(loc: CodeLocInfo) -> lspt.Range:
     )
 
 
+def get_location_range(mod_item: ast.ModuleItem) -> tuple[int, int, int, int]:
+    """Get location range."""
+    if not mod_item.from_mod_path.sub_module:
+        raise ValueError("Module items should have module path. Not Possible.")
+    lookup = mod_item.from_mod_path.sub_module.sym_tab.lookup(mod_item.name.value)
+    if not lookup:
+        raise ValueError("Module items should have a symbol table entry. Not Possible.")
+    loc = lookup.decl.loc
+    return loc.first_line, loc.col_start, loc.last_line, loc.col_end
+
+
 def kind_map(sub_tab: ast.AstNode) -> lspt.SymbolKind:
     """Map the symbol node to an lspt.SymbolKind."""
     return (

--- a/jaclang/runtimelib/importer.py
+++ b/jaclang/runtimelib/importer.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib
+import importlib.util
 import os
 import sys
 import types


### PR DESCRIPTION
### Description

This PR enhances the `go_to_definition` feature of the VSCE by leveraging the `abs_path` attribute of ModulePath and ModuleItem. 
This improvement allows users to navigate directly to the Python stub (`.pyi`) file when clicking on Python imports within a `jac` file.

### Key Improvement:

- Replaces the existing importlib approach with the abs_path attribute, enabling more precise navigation.

###  Example Usage:

```jac
import:py os;
import:py from math, sqrt as square_root;
import:py datetime as dt;
import:jac from base_module_structure, add;
import from base_module_structure, subtract;

with entry {
    for i in range(int(square_root(dt.datetime.now().year))) {
        print(os.getcwd(), add(i, subtract(i, 1)));
    }
}
```
In this example, when you click on os, getcwd, math, dt, datetime.now, base_module_structure, add, or subtract, you will be taken to the corresponding Python stub file/ Imported Jac file.

###  Limitation:
This PR does not support the `go_to_definition` feature for `ModuleItem` instances for unraised Python modules, as the abs_path attribute is available in ModulePath but not in ModuleItem. For instance, clicking on square_root (which is an alias for sqrt in the math module) will not take you to the Python stub file.

