### PR TITLE
Fix dot gen issue for  "__main__" module

### DIFF
--- a/examples/reference/connect_expressions.jac
+++ b/examples/reference/connect_expressions.jac
@@ -29,6 +29,6 @@ edge MyEdge {
     visit [-->];
 }
 
-with entry {
+with entry :__main__ {
     root spawn Creator();
 }

--- a/jaclang/cli/cli.py
+++ b/jaclang/cli/cli.py
@@ -431,8 +431,8 @@ def dot(
 
     if filename.endswith(".jac"):
         jac_machine = JacMachine(base)
-        jac_import(target=mod, base_path=base)
-        module = jac_machine.loaded_modules.get(mod)
+        jac_import(target=mod, base_path=base, override_name="__main__")
+        module = jac_machine.loaded_modules.get("__main__")
         globals().update(vars(module))
         try:
             node = globals().get(initial, eval(initial)) if initial else None

--- a/jaclang/tests/test_language.py
+++ b/jaclang/tests/test_language.py
@@ -173,7 +173,11 @@ class JacLanguageTests(TestCase):
         """Test the dot gen of nodes and edges of bubblesort."""
         captured_output = io.StringIO()
         sys.stdout = captured_output
-        jac_import("gendot_bubble_sort", base_path=self.fixture_abs_path("./"))
+        jac_import(
+            "gendot_bubble_sort",
+            base_path=self.fixture_abs_path("./"),
+            override_name="__main__",
+        )
         sys.stdout = sys.__stdout__
         stdout_value = captured_output.getvalue()
         self.assertIn(

--- a/jaclang/tests/test_language.py
+++ b/jaclang/tests/test_language.py
@@ -173,11 +173,7 @@ class JacLanguageTests(TestCase):
         """Test the dot gen of nodes and edges of bubblesort."""
         captured_output = io.StringIO()
         sys.stdout = captured_output
-        jac_import(
-            "gendot_bubble_sort",
-            base_path=self.fixture_abs_path("./"),
-            override_name="__main__",
-        )
+        jac_import("gendot_bubble_sort", base_path=self.fixture_abs_path("./"))
         sys.stdout = sys.__stdout__
         stdout_value = captured_output.getvalue()
         self.assertIn(


### PR DESCRIPTION
## **Description**

Ensures proper dot(graph) generation for modules using __main__.

 Existing test, `test_graph` in `test_cli`, validates this change. The test ensures the correctness of dot gen of reference/connect_expressions.jac` .